### PR TITLE
[Chore] Dependabot 자동 의존성 업데이트 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # npm 의존성: 매주 월요일 09:00 KST(UTC 00:00) minor/patch 업데이트 PR 생성
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "00:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "chore"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      # 같은 범주의 마이너/패치 업데이트는 하나의 PR로 묶기
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # 메이저 업데이트는 수동으로 검토(자동 PR 생성 안 함)
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # GitHub Actions 워크플로우에 사용된 action 버전도 자동 업데이트
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "ci"
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"


### PR DESCRIPTION
## 목적
의존성 취약점과 버전 관리를 자동화하기 위해 `.github/dependabot.yml`을 추가합니다.

## 변경 사항

### `.github/dependabot.yml` 신규
- **npm**: 매주 월요일 09:00 KST에 minor/patch 업데이트 PR 생성
  - `groups`로 minor/patch는 하나의 PR로 묶음 (PR 스팸 방지)
  - 메이저 업데이트는 `ignore`로 수동 검토
  - 오픈 PR 최대 5개 제한
  - 라벨: `chore`, `dependencies`
- **github-actions**: 매월 workflow 내 action 버전 업데이트
  - 라벨: `ci`, `dependencies`

## 함께 체크 필요 (Settings UI에서)
- [x] Dependency graph: **Enable**
- [x] Dependabot malware alerts: **Enable**
- [x] Dependabot security updates: **Enable** (보안 자동 PR 별도 기능)

## 효과
- 취약점 발견 시 자동 PR → 머지만 누르면 끝
- 라이브러리 노후화 방지 (특히 Next 16, React 19 같은 최신 스택 유지)
- 메이저 버전 업데이트는 수동 검토로 안전 확보

## 참고
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference