### PR TITLE
[Chore] CodeRabbit 설정 추가 (.coderabbit.yaml)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+# CodeRabbit 설정
+# docs: https://docs.coderabbit.ai/reference/yaml-template
+
+language: "ko-KR"
+early_access: false
+
+reviews:
+  profile: "chill"             # 'chill'은 과하지 않은 리뷰 톤. 'assertive'는 엄격
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false                  # 장난스러운 시 생성 off (PR이 가벼워짐)
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false              # draft PR은 리뷰 skip (완성 전)
+    base_branches:
+      - main
+      - develop
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/.next/**"
+    - "!**/dist/**"
+    - "!**/public/**"
+    - "!**/*.lock"
+    - "!package-lock.json"
+  path_instructions:
+    - path: "src/components/**"
+      instructions: |
+        컴포넌트 리뷰 시 다음을 중점 확인:
+        - 단일 책임 원칙 (컴포넌트 사이즈 300줄 이내 권장)
+        - props 타입 명확성
+        - 접근성 (a11y: aria, semantic HTML, keyboard navigation)
+        - 재사용 가능한 로직은 hook으로 분리 가능한지
+    - path: "src/api/**"
+      instructions: |
+        API 레이어 리뷰 시:
+        - 에러 처리 일관성
+        - 타입 추론 정확성
+        - `any` 사용 금지 (불가피하면 근거 주석 필수)
+    - path: "src/hooks/**"
+      instructions: |
+        React Query 훅 리뷰 시:
+        - queryKey 컨벤션 준수
+        - staleTime/gcTime 설정 적절성
+        - mutation 후 invalidateQueries 매핑
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## 목적
CodeRabbit(AI 코드 리뷰 봇) 설정 파일 추가. 설치 후 자동으로 적용됨.

## 설정 요약
- **언어**: 한국어 (`ko-KR`)
- **프로필**: `chill` — 과하지 않은 리뷰 톤 (멘티 학습 배려)
- **auto_review**: main/develop 타깃 PR에 자동 적용
- **draft PR**: skip (완성 전 리뷰 X)
- **path 기반 가이드** 제공:
  - `src/components/**` → 단일 책임, a11y, 재사용성
  - `src/api/**` → 에러 처리, 타입, `any` 금지
  - `src/hooks/**` → queryKey 컨벤션, 캐시 전략
- **path_filters**: `node_modules`, `.next`, `dist`, `lock` 파일 제외

## 사전 요구 사항
1. CodeRabbit GitHub App을 레포에 설치
   - https://coderabbit.ai → GitHub 연동 → `cbu-manage/frontend` 설치
2. 이 PR 머지 후 다음 PR부터 자동으로 한국어 리뷰 시작

## 효과
- Vercel(미리보기 배포) + CodeRabbit(코드 리뷰) 2중 안전망
- 멘티 PR 품질 자동 체크
- PR 작성자에게 학습 효과 (인라인 코멘트로 설명 제공)

## 조정 팁
- 처음 몇 주간은 `profile: "chill"`로 두고 팀 적응 후 `assertive`로 올릴 수 있음
- 코멘트가 너무 많아지면 `path_filters` 추가 또는 `poem: false`로 간결화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 개발 프로세스 최적화를 위한 설정 파일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->