### PR TITLE
chore(ci): dependabot PR 대상 브랜치를 develop으로 변경

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # npm 의존성: 매주 월요일 09:00 KST(UTC 00:00) minor/patch 업데이트 PR 생성
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -32,6 +33,7 @@ updates:
   # GitHub Actions 워크플로우에 사용된 action 버전도 자동 업데이트
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
## Summary
- dependabot 자동 PR이 `main`이 아닌 `develop` 브랜치로 가도록 `target-branch: \"develop\"` 추가
- npm 블록, github-actions 블록 둘 다 적용

## Why
- dependabot은 default branch(`main`)의 설정만 읽기 때문에 이 PR은 main으로 직접 머지해야 효력 발생
- 이번 #148 같은 의존성 PR이 앞으로는 자동으로 develop 대상이 됨

## Test plan
- [ ] 머지 후 다음 dependabot 실행에서 새 PR이 develop 대상으로 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동 의존성 업데이트 관리 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->