### PR TITLE
Feat: userStore userId·role 저장 + useIsAuthor 훅

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -81,6 +81,21 @@ app/manage/page.tsx        ← 얇음. 인증가드 + PageClient만
 
 ---
 
-## 6. 새 컴포넌트 어디에?
+## 6. 본인 게시물 수정/삭제 버튼 — `useIsAuthor`
+
+게시판 어디서든 "내 글일 때만 수정/삭제"는 **`useIsAuthor` 훅**으로 통일한다 (직접 `userId` 비교 X).
+
+```tsx
+import { useIsAuthor } from "@/hooks/auth";
+
+const { canModify } = useIsAuthor(post.authorId, post.isAuthor);
+// ...
+{canModify && <EditDeleteButtons />}
+```
+- 서버가 `isAuthor`를 주면(study/codingTest 등) 그걸 우선, 없으면 내 `userId === authorId` 비교.
+- `canModify` = 본인 || 관리자(isAdmin).
+- ⚠️ **UI 게이팅일 뿐** — 실제 권한은 서버가 401/200으로 최종 판정. 버튼 숨겼다고 끝 아님.
+
+## 7. 새 컴포넌트 어디에?
 
 범용 폼입력 → `common/` · 전역 레이아웃 → `shared/` · 관리자 기능 → `admin/` + `*Section` · 마이 기능 → `user/` + `*Section` · 리스트 카드 → 도메인 폴더 + `*Card` · 인증 가드 → `auth/` + `Require*` · 멀티스텝 폼 → `signup/` + `Step*` · 페이지 래퍼 → 라우트명 + `*PageClient` · SVG 아이콘 → `icons/`.

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -2,3 +2,4 @@ export { useLogin } from "./useLogin";
 export { useSignUp } from "./useSignUp";
 export { useChangePassword } from "./useChangePassword";
 export { useMe, ME_QUERY_KEY } from "./useMe";
+export { useIsAuthor } from "./useIsAuthor";

--- a/src/hooks/auth/useIsAuthor.ts
+++ b/src/hooks/auth/useIsAuthor.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useUserStore } from "@/store/userStore";
+
+/**
+ * 게시물 소유 여부 판단 — 수정/삭제 버튼 노출용 (UI 게이팅 전용).
+ * ⚠️ 실제 권한은 서버가 최종 판정(401/200)한다. 이 훅은 버튼 보임/숨김일 뿐.
+ *
+ * 우선순위:
+ *  1) 서버가 내려준 isAuthor (study/codingTest 등) — 있으면 그대로 신뢰
+ *  2) 없으면 내 userId === 게시물 authorId 비교 (number/uuid 무관하게 String 비교)
+ * canModify = 본인 || 관리자(isAdmin).
+ *
+ * @example
+ *   const { canModify } = useIsAuthor(post.authorId, post.isAuthor);
+ *   {canModify && <EditDeleteButtons />}
+ */
+export function useIsAuthor(
+  authorId?: string | number | null,
+  serverIsAuthor?: boolean,
+) {
+  const userId = useUserStore((s) => s.userId);
+  const isAdmin = useUserStore((s) => s.isAdmin);
+
+  const isAuthor =
+    serverIsAuthor ??
+    (!!userId && authorId != null && String(userId) === String(authorId));
+
+  return { isAuthor, canModify: isAuthor || isAdmin };
+}

--- a/src/hooks/auth/useLogin.ts
+++ b/src/hooks/auth/useLogin.ts
@@ -47,6 +47,7 @@ export function useLogin() {
 
       if (isAdmin) {
         setUser({
+          role: data.role,
           name: data.name,
           studentNumber,
           email: loginEmail,
@@ -64,6 +65,7 @@ export function useLogin() {
       const isEmailNull = !hasValidEmail;
 
       setUser({
+        role: data.role,
         name: data.name,
         studentNumber,
         email: hasValidEmail ? loginEmail : null,

--- a/src/hooks/auth/useMe.ts
+++ b/src/hooks/auth/useMe.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { authApi, type MeResponseData } from "@/api/auth.api";
 import { useUserStore } from "@/store/userStore";
@@ -9,11 +10,13 @@ export const ME_QUERY_KEY = ["auth", "me"] as const;
 /**
  * 로그인한 사용자 정보(/login/me).
  * userStore에 name이 있을 때만 조회 — 비로그인 상태에선 401 피하려고 skip.
+ * 응답을 받으면 userStore에 hydrate(userId·role 포함) — 본인 게시물 판별/권한용.
  */
 export function useMe() {
   const isLoggedIn = useUserStore((s) => !!s.name);
+  const setUser = useUserStore((s) => s.setUser);
 
-  return useQuery<MeResponseData>({
+  const query = useQuery<MeResponseData>({
     queryKey: ME_QUERY_KEY,
     queryFn: async () => {
       const res = await authApi.me();
@@ -22,4 +25,22 @@ export function useMe() {
     enabled: isLoggedIn,
     staleTime: 5 * 60 * 1000,
   });
+
+  useEffect(() => {
+    const me = query.data;
+    if (!me) return;
+    const isAdmin = !!me.role && me.role.toUpperCase().includes("ADMIN");
+    setUser({
+      userId: String(me.userId), // number/uuid 무관하게 문자열로 보관
+      role: me.role,
+      name: me.name,
+      studentNumber: me.studentNumber,
+      email: me.email,
+      major: me.major,
+      grade: me.grade,
+      isAdmin,
+    });
+  }, [query.data, setUser]);
+
+  return query;
 }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
 type UserInfo = {
+  userId: string; // 서버 식별자(uuid). 본인 게시물 판별(authorId 비교)용 — useIsAuthor 참고
+  role: string; // 서버가 내려주는 권한 문자열 (권한 세분화용). isAdmin은 이걸로 파생
   name: string;
   studentNumber: number;
   email: string | null;
@@ -26,6 +28,8 @@ type UserStore = UserInfo & {
 };
 
 const initialState: UserInfo = {
+  userId: '',
+  role: '',
   name: '',
   studentNumber: 0,
   email: null,
@@ -64,6 +68,8 @@ export const useUserStore = create<UserStore>()(
       setUser: (info) =>
         set((s) => ({
           ...s,
+          userId: info.userId ?? s.userId,
+          role: info.role ?? s.role,
           name: info.name ?? s.name,
           studentNumber: info.studentNumber ?? s.studentNumber,
           email: info.email ?? s.email,
@@ -101,6 +107,8 @@ export const useUserStore = create<UserStore>()(
         return localStorage;
       }),
       partialize: (state) => ({
+        userId: state.userId,
+        role: state.role,
         name: state.name,
         studentNumber: state.studentNumber,
         email: state.email,


### PR DESCRIPTION
## 목적
본인 게시물 수정/삭제 판별 + 권한(role) 저장의 공통 토대. 관련: #123(토큰/권한), #118(권한 세분화).

## 변경
- **userStore**: `userId`(uuid)·`role` 필드 추가 (persist 포함)
- **useMe**: `/login/me` 응답을 store에 hydrate (userId·role·isAdmin 파생)
- **useLogin**: 로그인 시 `role` 즉시 저장
- **useIsAuthor**: 본인 게시물 판별 훅
  - 서버 `isAuthor` 우선(study/codingTest) → 없으면 `userId===authorId`
  - `String()` 비교라 number/uuid 전환 무관
  - `canModify = 본인 || isAdmin`, **UI 게이팅 전용**(실권한은 서버 401/200)
- **docs/components.md**: 사용법 추가

## 사용 (모든 게시판 공통)
```tsx
const { canModify } = useIsAuthor(post.authorId, post.isAuthor);
{canModify && <EditDeleteButtons />}
```

## 비고
- BE가 `login`/`me`에 **uuid userId** 내려주면 바로 동작 (미리 만들어둠)
- 검증: `npm run build` ✅ / `npm run lint` 0 errors