### PR TITLE
Feat: 헤더 재설계 (카테고리 + 드롭다운)

### DIFF
--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -125,7 +125,7 @@ export default function Header() {
                     {cat.name}
                   </button>
                   {/* 항목 — 카테고리 바로 아래 정렬, 셸프 위에 표시 (pt-5=hover 브릿지) */}
-                  <div className="invisible opacity-0 group-hover/cat:visible group-hover/cat:opacity-100 group-focus-within/cat:visible group-focus-within/cat:opacity-100 absolute left-0 top-full z-40 pt-5 transition-opacity">
+                  <div className="invisible opacity-0 group-hover/cat:visible group-hover/cat:opacity-100 group-focus-within/cat:visible group-focus-within/cat:opacity-100 absolute left-1/2 -translate-x-1/2 top-full z-40 pt-5 transition-opacity">
                     <ul className="flex flex-col gap-1 min-w-44">
                       {cat.items.map((item) => {
                         const itemActive = pathname.startsWith(item.path);
@@ -133,14 +133,12 @@ export default function Header() {
                           <li key={item.path}>
                             <Link
                               href={item.path}
-                              className={`block rounded-xl px-4 py-2.5 text-base font-medium transition-colors ${
+                              className={`block text-center rounded-xl px-4 py-2.5 text-base font-medium transition-colors ${
                                 itemActive
-                                  ? isHome
-                                    ? "bg-white/10 text-brand"
-                                    : "bg-gray-100 text-brand"
+                                  ? "bg-brand/15 text-brand font-semibold"
                                   : isHome
-                                    ? "text-white/90 hover:bg-white/10"
-                                    : "text-gray-700 hover:bg-gray-100"
+                                    ? "text-white/90 hover:bg-white/10 hover:text-brand"
+                                    : "text-gray-700 hover:bg-brand/10 hover:text-brand"
                               }`}
                             >
                               {item.name}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -2,9 +2,43 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import { Menu, X } from "lucide-react";
+import { ChevronDown, Menu, X } from "lucide-react";
 import { useUserStore } from "@/store/userStore";
 import { authApi } from "@/api";
+
+/**
+ * 헤더 네비게이션 — 카테고리(의미 그룹) + 드롭다운.
+ * 항목 추가는 이 배열만 수정하면 됨 (예: 아카이브에 명예의 전당).
+ */
+type NavItem = { name: string; path: string };
+type NavCategory = { name: string; items: NavItem[] };
+
+const NAV: NavCategory[] = [
+  {
+    name: "씨부엉 소식",
+    items: [
+      { name: "공지사항", path: "/notice" },
+      { name: "소식게시판", path: "/news" },
+      { name: "자료방", path: "/archive" },
+    ],
+  },
+  {
+    name: "네트워킹",
+    items: [
+      { name: "스터디 모집", path: "/study" },
+      { name: "프로젝트 모집", path: "/project" },
+      { name: "자유게시판", path: "/board" },
+    ],
+  },
+  {
+    name: "알고리즘",
+    items: [{ name: "코딩 테스트 준비", path: "/coding-test" }],
+  },
+  {
+    name: "아카이브",
+    items: [{ name: "보고서 업로드", path: "/report" }],
+  },
+];
 
 export default function Header() {
   const pathname = usePathname();
@@ -16,18 +50,19 @@ export default function Header() {
   const isBlockHeader = pathname === "/memberManage";
   const isHome = pathname === "/";
 
+  // 모바일 메뉴: 현재 pathname에서 열림 → 이동(경로 변경) 시 파생적으로 닫힘
   const [openedAtPathname, setOpenedAtPathname] = useState<string | null>(null);
   const mobileOpen = openedAtPathname === pathname && openedAtPathname !== null;
+  const [expandedCat, setExpandedCat] = useState<string | null>(null);
 
   const toggleMenu = () => setOpenedAtPathname(mobileOpen ? null : pathname);
-  const closeMenu = () => setOpenedAtPathname(null);
+  const closeMenu = () => {
+    setOpenedAtPathname(null);
+    setExpandedCat(null);
+  };
 
   useEffect(() => {
-    if (mobileOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
+    document.body.style.overflow = mobileOpen ? "hidden" : "";
     return () => {
       document.body.style.overflow = "";
     };
@@ -44,59 +79,87 @@ export default function Header() {
     window.location.href = "/";
   };
 
-  const navItems = [
-    { name: "스터디 모집", path: "/study" },
-    { name: "프로젝트 모집", path: "/project" },
-    { name: "코딩테스트 준비", path: "/coding-test" },
-    { name: "보고서 업로드", path: "/report" },
-    { name: "자료방", path: "/archive" },
-  ];
+  const isCategoryActive = (cat: NavCategory) =>
+    cat.items.some((i) => pathname.startsWith(i.path));
+
+  // 테마 토큰 (홈=다크, 나머지=라이트). 추후 #177에서 테마 상태 기반으로 일반화.
+  const text = isHome ? "text-white" : "text-gray-700";
+  const panelBg = isHome
+    ? "bg-[#1f1f22] border-white/10"
+    : "bg-gray-0 border-gray-200";
+  const itemHover = isHome
+    ? "text-white/90 hover:bg-white/10"
+    : "text-gray-700 hover:bg-gray-50";
+  const ctaBtn = isHome
+    ? "bg-white text-black hover:opacity-90"
+    : "bg-brand text-white hover:opacity-90";
+
+  if (isBlockHeader) {
+    return <header className="border-b border-gray-200" />;
+  }
 
   return (
     <header
-      className={
-        isBlockHeader
-          ? "border-b border-gray-200"
-          : `sticky top-0 w-full z-40 border-b ${isHome ? "bg-[#151517] border-transparent" : "bg-gray-0 border-gray-200"}`
-      }
+      className={`sticky top-0 w-full z-40 border-b ${
+        isHome ? "bg-[#151517] border-transparent" : "bg-gray-0 border-gray-200"
+      }`}
     >
-      <div
-        className={`flex items-center gap-4 md:gap-8 container-x py-4 md:py-6 ${isHome ? "bg-[#151517]" : "bg-gray-0"}`}
-      >
+      <div className="flex items-center gap-4 md:gap-8 container-x py-4 md:py-6">
         <Link href="/" className="shrink-0">
-          <img src="/assets/logo.png" alt="로고이미지" className="h-7 md:h-8 w-auto" />
+          <img src="/assets/logo.png" alt="씨부엉" className="h-7 md:h-8 w-auto" />
         </Link>
 
+        {/* 데스크탑 카테고리 네비 (hover/focus 드롭다운) */}
         <nav className="hidden md:flex flex-1 justify-center">
-          <ul className={`flex items-center gap-8 text-base font-medium ${isHome ? "text-white" : "text-gray-700"}`}>
-            {navItems.map((item) => (
-              <li key={item.path}>
-                <Link
-                  href={item.path}
-                  className={`transition-colors ${isHome ? "hover:text-brand" : "hover:text-brand"} ${
-                    pathname.startsWith(item.path)
-                      ? "text-brand font-semibold"
-                      : isHome
-                        ? "text-white"
-                        : "text-gray-700"
-                  }`}
-                >
-                  {item.name}
-                </Link>
-              </li>
-            ))}
+          <ul className={`flex items-center gap-10 lg:gap-14 text-base font-medium ${text}`}>
+            {NAV.map((cat) => {
+              const active = isCategoryActive(cat);
+              return (
+                <li key={cat.name} className="group relative">
+                  <button
+                    type="button"
+                    className={`inline-flex items-center gap-1 pb-1.5 border-b-2 transition-colors ${
+                      active
+                        ? "border-brand text-brand font-semibold"
+                        : "border-transparent group-hover:text-brand"
+                    }`}
+                    aria-haspopup="true"
+                  >
+                    {cat.name}
+                    <ChevronDown
+                      size={16}
+                      className="opacity-70 transition-transform group-hover:rotate-180"
+                    />
+                  </button>
+                  {/* 드롭다운 — 마우스 hover + 키보드 focus-within에서 노출. 바깥 div의 pt-3=hover 브릿지 */}
+                  <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 absolute left-0 top-full pt-3 transition-opacity">
+                    <ul className={`min-w-44 rounded-2xl border p-2 shadow-lg ${panelBg}`}>
+                      {cat.items.map((item) => (
+                        <li key={item.path}>
+                          <Link
+                            href={item.path}
+                            className={`block rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
+                              pathname.startsWith(item.path) ? "text-brand" : itemHover
+                            }`}
+                          >
+                            {item.name}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         </nav>
 
+        {/* 데스크탑 우측 — 로그인 상태 */}
         <div className="hidden md:flex items-center gap-4 justify-end flex-none">
           {!isLoggedIn ? (
             <Link
               href="/login"
-              className={`flex items-center justify-center px-3 py-1.5 gap-[7px] rounded-lg text-base font-semibold leading-[140%] tracking-[-0.06px] transition-colors ${
-                isHome
-                  ? "bg-white text-black hover:opacity-90"
-                  : "bg-brand text-white hover:opacity-90"
-              }`}
+              className={`flex items-center justify-center px-5 py-2 rounded-lg text-base font-semibold transition-colors ${ctaBtn}`}
             >
               로그인
             </Link>
@@ -104,21 +167,17 @@ export default function Header() {
             <>
               <Link
                 href={isAdmin ? "/manage" : "/user"}
-                className={`transition-colors hover:text-brand ${
+                className={`font-medium transition-colors hover:text-brand ${
                   (isAdmin ? pathname.startsWith("/manage") : pathname.startsWith("/user"))
                     ? "text-brand font-semibold"
-                    : isHome ? "text-white font-medium" : "text-gray-700 font-medium"
+                    : text
                 }`}
               >
                 {isAdmin ? "관리자 페이지" : "마이페이지"}
               </Link>
               <button
                 onClick={handleLogout}
-                className={`flex items-center justify-center px-3 py-1.5 gap-[7px] rounded-lg text-base font-semibold leading-[140%] tracking-[-0.06px] transition-colors ${
-                  isHome
-                    ? "bg-white text-black hover:opacity-90"
-                    : "bg-brand text-white hover:opacity-90"
-                }`}
+                className={`flex items-center justify-center px-5 py-2 rounded-lg text-base font-semibold transition-colors ${ctaBtn}`}
               >
                 로그아웃
               </button>
@@ -126,6 +185,7 @@ export default function Header() {
           )}
         </div>
 
+        {/* 모바일 햄버거 */}
         <button
           type="button"
           onClick={toggleMenu}
@@ -139,6 +199,7 @@ export default function Header() {
         </button>
       </div>
 
+      {/* 모바일 메뉴 — 카테고리 아코디언 */}
       {mobileOpen && (
         <>
           <div
@@ -147,39 +208,59 @@ export default function Header() {
             aria-hidden="true"
           />
           <div
-            className={`md:hidden absolute left-0 right-0 top-full z-40 border-t ${
+            className={`md:hidden absolute left-0 right-0 top-full z-40 border-t max-h-[80vh] overflow-y-auto ${
               isHome ? "bg-[#151517] border-white/10" : "bg-gray-0 border-gray-200"
             }`}
           >
             <nav className="px-4 py-3">
               <ul className="flex flex-col">
-                {navItems.map((item) => {
-                  const active = pathname.startsWith(item.path);
+                {NAV.map((cat) => {
+                  const open = expandedCat === cat.name;
+                  const active = isCategoryActive(cat);
                   return (
-                    <li key={item.path}>
-                      <Link
-                        href={item.path}
-                        className={`block px-3 py-3 rounded-lg text-base font-medium ${
-                          active
-                            ? "text-brand font-semibold"
-                            : isHome
-                              ? "text-white hover:bg-white/10"
-                              : "text-gray-700 hover:bg-gray-50"
+                    <li key={cat.name}>
+                      <button
+                        type="button"
+                        onClick={() => setExpandedCat(open ? null : cat.name)}
+                        aria-expanded={open}
+                        className={`w-full flex items-center justify-between px-3 py-3 rounded-lg text-base font-semibold ${
+                          active ? "text-brand" : text
                         }`}
                       >
-                        {item.name}
-                      </Link>
+                        {cat.name}
+                        <ChevronDown
+                          size={18}
+                          className={`transition-transform ${open ? "rotate-180" : ""}`}
+                        />
+                      </button>
+                      {open && (
+                        <ul className="pb-1">
+                          {cat.items.map((item) => (
+                            <li key={item.path}>
+                              <Link
+                                href={item.path}
+                                className={`block pl-6 pr-3 py-2.5 rounded-lg text-sm font-medium ${
+                                  pathname.startsWith(item.path)
+                                    ? "text-brand font-semibold"
+                                    : itemHover
+                                }`}
+                              >
+                                {item.name}
+                              </Link>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </li>
                   );
                 })}
               </ul>
+
               <div className={`mt-3 pt-3 border-t ${isHome ? "border-white/10" : "border-gray-200"} flex flex-col gap-2`}>
                 {!isLoggedIn ? (
                   <Link
                     href="/login"
-                    className={`flex items-center justify-center px-3 py-3 rounded-lg text-base font-semibold ${
-                      isHome ? "bg-white text-black" : "bg-brand text-white"
-                    }`}
+                    className={`flex items-center justify-center px-3 py-3 rounded-lg text-base font-semibold ${ctaBtn}`}
                   >
                     로그인
                   </Link>
@@ -195,9 +276,7 @@ export default function Header() {
                     </Link>
                     <button
                       onClick={handleLogout}
-                      className={`flex items-center justify-center px-3 py-3 rounded-lg text-base font-semibold ${
-                        isHome ? "bg-white text-black" : "bg-brand text-white"
-                      }`}
+                      className={`flex items-center justify-center px-3 py-3 rounded-lg text-base font-semibold ${ctaBtn}`}
                     >
                       로그아웃
                     </button>

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -108,7 +108,7 @@ export default function Header() {
 
         {/* 데스크탑 카테고리 네비 — 메가메뉴(헤더 전체폭 펼침) */}
         <nav className="hidden md:flex flex-1 justify-center group/cats">
-          <ul className={`flex items-center gap-14 lg:gap-20 text-base font-medium ${text}`}>
+          <ul className={`flex items-center gap-20 lg:gap-24 text-base font-medium ${text}`}>
             {NAV.map((cat) => {
               const active = isCategoryActive(cat);
               return (

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -108,7 +108,7 @@ export default function Header() {
 
         {/* 데스크탑 카테고리 네비 — 메가메뉴(헤더 전체폭 펼침) */}
         <nav className="hidden md:flex flex-1 justify-center group/cats">
-          <ul className={`flex items-center gap-10 lg:gap-14 text-base font-medium ${text}`}>
+          <ul className={`flex items-center gap-14 lg:gap-20 text-base font-medium ${text}`}>
             {NAV.map((cat) => {
               const active = isCategoryActive(cat);
               return (

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -125,7 +125,7 @@ export default function Header() {
                     {cat.name}
                   </button>
                   {/* 항목 — 카테고리 바로 아래 정렬, 셸프 위에 표시 (pt-5=hover 브릿지) */}
-                  <div className="invisible opacity-0 group-hover/cat:visible group-hover/cat:opacity-100 group-focus-within/cat:visible group-focus-within/cat:opacity-100 absolute left-1/2 -translate-x-1/2 top-full z-40 pt-5 transition-opacity">
+                  <div className="invisible opacity-0 group-hover/cats:visible group-hover/cats:opacity-100 group-focus-within/cats:visible group-focus-within/cats:opacity-100 absolute left-1/2 -translate-x-1/2 top-full z-40 pt-5 transition-opacity">
                     <ul className="flex flex-col gap-1 min-w-44">
                       {cat.items.map((item) => {
                         const itemActive = pathname.startsWith(item.path);

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -118,7 +118,7 @@ export default function Header() {
                 <li key={cat.name} className="group relative">
                   <button
                     type="button"
-                    className={`inline-flex items-center gap-1 pb-1.5 border-b-2 transition-colors ${
+                    className={`pb-1.5 border-b-4 transition-colors ${
                       active
                         ? "border-brand text-brand font-semibold"
                         : "border-transparent group-hover:text-brand"
@@ -126,10 +126,6 @@ export default function Header() {
                     aria-haspopup="true"
                   >
                     {cat.name}
-                    <ChevronDown
-                      size={16}
-                      className="opacity-70 transition-transform group-hover:rotate-180"
-                    />
                   </button>
                   {/* 드롭다운 — 마우스 hover + 키보드 focus-within에서 노출. 바깥 div의 pt-3=hover 브릿지 */}
                   <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 absolute left-0 top-full pt-3 transition-opacity">

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -108,17 +108,17 @@ export default function Header() {
 
         {/* 데스크탑 카테고리 네비 — 메가메뉴(헤더 전체폭 펼침) */}
         <nav className="hidden md:flex flex-1 justify-center group/cats">
-          <ul className={`flex items-center gap-20 lg:gap-24 text-base font-medium ${text}`}>
+          <ul className={`flex items-center gap-20 lg:gap-32 text-lg font-semibold ${text}`}>
             {NAV.map((cat) => {
               const active = isCategoryActive(cat);
               return (
                 <li key={cat.name} className="group/cat relative">
                   <button
                     type="button"
-                    className={`pb-1.5 border-b-4 transition-colors ${
+                    className={`pb-1.5 border-b-4 font-semibold transition-colors ${
                       active
-                        ? "border-brand text-brand font-semibold"
-                        : "border-transparent group-hover/cat:text-brand"
+                        ? "border-brand text-brand"
+                        : `border-transparent group-hover/cat:text-brand ${isHome ? "text-white" : "text-gray-900"}`
                     }`}
                     aria-haspopup="true"
                   >

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -125,7 +125,7 @@ export default function Header() {
                     {cat.name}
                   </button>
                   {/* 항목 — 카테고리 바로 아래 정렬, 셸프 위에 표시 (pt-5=hover 브릿지) */}
-                  <div className="invisible opacity-0 group-hover/cats:visible group-hover/cats:opacity-100 group-focus-within/cats:visible group-focus-within/cats:opacity-100 absolute left-1/2 -translate-x-1/2 top-full z-40 pt-5 transition-opacity">
+                  <div className="invisible opacity-0 group-hover/cat:visible group-hover/cat:opacity-100 group-focus-within/cat:visible group-focus-within/cat:opacity-100 absolute left-1/2 -translate-x-1/2 top-full z-40 pt-5 transition-opacity">
                     <ul className="flex flex-col gap-1 min-w-44">
                       {cat.items.map((item) => {
                         const itemActive = pathname.startsWith(item.path);

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -84,9 +84,6 @@ export default function Header() {
 
   // 테마 토큰 (홈=다크, 나머지=라이트). 추후 #177에서 테마 상태 기반으로 일반화.
   const text = isHome ? "text-white" : "text-gray-700";
-  const panelBg = isHome
-    ? "bg-[#1f1f22] border-white/10"
-    : "bg-gray-0 border-gray-200";
   const itemHover = isHome
     ? "text-white/90 hover:bg-white/10"
     : "text-gray-700 hover:bg-gray-50";
@@ -109,45 +106,61 @@ export default function Header() {
           <img src="/assets/logo.png" alt="씨부엉" className="h-7 md:h-8 w-auto" />
         </Link>
 
-        {/* 데스크탑 카테고리 네비 (hover/focus 드롭다운) */}
-        <nav className="hidden md:flex flex-1 justify-center">
+        {/* 데스크탑 카테고리 네비 — 메가메뉴(헤더 전체폭 펼침) */}
+        <nav className="hidden md:flex flex-1 justify-center group/cats">
           <ul className={`flex items-center gap-10 lg:gap-14 text-base font-medium ${text}`}>
             {NAV.map((cat) => {
               const active = isCategoryActive(cat);
               return (
-                <li key={cat.name} className="group relative">
+                <li key={cat.name} className="group/cat relative">
                   <button
                     type="button"
                     className={`pb-1.5 border-b-4 transition-colors ${
                       active
                         ? "border-brand text-brand font-semibold"
-                        : "border-transparent group-hover:text-brand"
+                        : "border-transparent group-hover/cat:text-brand"
                     }`}
                     aria-haspopup="true"
                   >
                     {cat.name}
                   </button>
-                  {/* 드롭다운 — 마우스 hover + 키보드 focus-within에서 노출. 바깥 div의 pt-3=hover 브릿지 */}
-                  <div className="invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 absolute left-0 top-full pt-3 transition-opacity">
-                    <ul className={`min-w-44 rounded-2xl border p-2 shadow-lg ${panelBg}`}>
-                      {cat.items.map((item) => (
-                        <li key={item.path}>
-                          <Link
-                            href={item.path}
-                            className={`block rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
-                              pathname.startsWith(item.path) ? "text-brand" : itemHover
-                            }`}
-                          >
-                            {item.name}
-                          </Link>
-                        </li>
-                      ))}
+                  {/* 항목 — 카테고리 바로 아래 정렬, 셸프 위에 표시 (pt-5=hover 브릿지) */}
+                  <div className="invisible opacity-0 group-hover/cat:visible group-hover/cat:opacity-100 group-focus-within/cat:visible group-focus-within/cat:opacity-100 absolute left-0 top-full z-40 pt-5 transition-opacity">
+                    <ul className="flex flex-col gap-1 min-w-44">
+                      {cat.items.map((item) => {
+                        const itemActive = pathname.startsWith(item.path);
+                        return (
+                          <li key={item.path}>
+                            <Link
+                              href={item.path}
+                              className={`block rounded-xl px-4 py-2.5 text-base font-medium transition-colors ${
+                                itemActive
+                                  ? isHome
+                                    ? "bg-white/10 text-brand"
+                                    : "bg-gray-100 text-brand"
+                                  : isHome
+                                    ? "text-white/90 hover:bg-white/10"
+                                    : "text-gray-700 hover:bg-gray-100"
+                              }`}
+                            >
+                              {item.name}
+                            </Link>
+                          </li>
+                        );
+                      })}
                     </ul>
                   </div>
                 </li>
               );
             })}
           </ul>
+          {/* 전체폭 셸프 — 카테고리 hover 시 헤더가 통째로 펼쳐지는 배경 */}
+          <div
+            aria-hidden="true"
+            className={`invisible opacity-0 group-hover/cats:visible group-hover/cats:opacity-100 absolute inset-x-0 top-full z-30 h-44 border-b transition-opacity ${
+              isHome ? "bg-[#151517] border-white/10" : "bg-gray-0 border-gray-200"
+            }`}
+          />
         </nav>
 
         {/* 데스크탑 우측 — 로그인 상태 */}


### PR DESCRIPTION
## 변경
새 디자인 반영 — 개별 링크 → **카테고리 4개 + 드롭다운**.

| 카테고리 | 드롭다운 |
|---|---|
| 씨부엉 소식 | 공지사항·소식게시판·자료방 |
| 네트워킹 | 스터디·프로젝트·자유게시판 |
| 알고리즘 | 코딩 테스트 준비 |
| 아카이브 | 보고서 업로드 *(추후 명예의전당 #120)* |

- **config 배열(NAV)** 기반 → 항목 추가 = 배열 한 줄
- 데스크탑: hover/focus-within 드롭다운(순수 CSS, state 없음), 활성 카테고리 brand 밑줄
- 모바일: 햄버거 → 카테고리 아코디언
- 다크(홈)/라이트 분기 유지. 다크 토글 일반화는 #177
- 절대좌표 Figma export 안 씀 — 반응형/토큰으로 재작성

## 검증
- build ✅ / lint 0 errors (img 경고는 기존)
- **Vercel preview에서 실제 모양 확인 필요** (드롭다운 hover·모바일 아코디언)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 네비게이션을 카테고리-항목 구조로 개편했습니다.
  * 데스크톱에서 카테고리별 드롭다운을 호버/포커스 시 표시합니다.
  * 모바일 메뉴에 카테고리 아코디언을 추가했습니다.

* **Bug Fixes**
  * 모바일 메뉴가 페이지 이동 시 자동으로 닫히도록 개선했습니다.
  * 모바일 메뉴가 열려 있을 때 배경 스크롤이 차단되도록 했습니다.

* **UI 변경**
  * 모바일 메뉴의 백드롭 동작이 제거되고, 메뉴 컨테이너 중심으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->