### PR TITLE
Feat: 범용 훅/유틸 + 공통 자산 카탈로그

### DIFF
--- a/docs/toolbox.md
+++ b/docs/toolbox.md
@@ -1,0 +1,62 @@
+# 공통 자산 카탈로그 (갖다 쓰세요)
+
+새로 만들기 전에 **여기 있는지 먼저 확인**. 있으면 import해서 쓰고, 없으면 [components.md](./components.md) 규칙대로 추가.
+
+---
+
+## 🪝 범용 훅 (`@/hooks`)
+
+| 훅 | 뭐냐 / 언제 | 예시 |
+|---|---|---|
+| `useDisclosure` | 열림/닫힘 상태. **모달·드롭다운·아코디언** | `const m = useDisclosure(); m.open(); {m.isOpen && ...}` |
+| `useDebounce` | 값이 멈춘 뒤 반영. **검색 입력** | `const q = useDebounce(keyword, 300)` |
+| `useClickOutside` | 바깥 클릭 감지. **드롭다운·팝오버 닫기** | `const ref = useClickOutside(() => setOpen(false))` |
+| `useIsAuthor` | 내 글인지 판별. **수정/삭제 버튼** | `const { canModify } = useIsAuthor(post.authorId, post.isAuthor)` |
+| `useMe` | 로그인 사용자(/me) 조회 + store hydrate | `const { data } = useMe()` |
+
+```tsx
+import { useDisclosure, useDebounce, useClickOutside } from "@/hooks";
+```
+
+> 도메인 데이터 훅(`useStudyList`, `useProjectList`, `useResourceList`…)도 `@/hooks`에 있음 — 목록/조회는 새로 만들지 말고 패턴 따라 추가. ([api.md](./api.md))
+
+---
+
+## 🧰 유틸 (`@/lib`)
+
+| 유틸 | 뭐냐 | 예시 |
+|---|---|---|
+| `cn` | 조건부 className 합성(clsx+tw-merge) | `cn("base", isActive && "text-brand")` |
+| `formatDate` | 날짜 포맷(서버 ISO→문자열) | `formatDate(post.createdAt)` → `2026.06.18` |
+| `formatRelativeTime` | 상대 시간 | `formatRelativeTime(post.createdAt)` → `3시간 전` |
+
+```tsx
+import { cn } from "@/lib/utils";
+import { formatDate, formatRelativeTime } from "@/lib/date";
+```
+
+---
+
+## 🧱 공통 컴포넌트 (`@/components`)
+
+| 컴포넌트 | 위치 | 용도 |
+|---|---|---|
+| `InputBox` | common | 폼 입력(라벨·에러·success) |
+| `LongBtn` / `ShortBtn` / `OutlineBtn` | common | 버튼 변형 |
+| `Toggle` | common | 토글 스위치 |
+| `MultiSelect` | common | 다중 선택 |
+| `LoadingSpinner` | common | 로딩 표시 |
+| `ErrorFallback` | common | 에러 화면 |
+| `Calendar` | common | 날짜 선택 |
+| `Header` / `Footer` / `Sidebar` / `Pagination` | shared | 전역 레이아웃 |
+| `Button` | ui | shadcn 프리미티브 |
+| `RequireMember` / `RequireAdmin` | auth | 페이지 접근 가드 |
+
+> ⚠️ Figma 디자인 시스템 컴포넌트(버튼/칩/모달 등)는 **Storybook 브랜치에서 추출 예정**. 중복 만들지 말고 그쪽 확인.
+
+---
+
+## 원칙
+- **새로 만들기 전에 이 표 확인** → 있으면 재사용.
+- 색·사이즈는 토큰([styling.md](./styling.md)), API는 `@/api`+훅([api.md](./api.md)).
+- 새 공통 자산 추가하면 **이 문서에도 한 줄 추가**.

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,0 +1,3 @@
+export { useDisclosure } from "./useDisclosure";
+export { useDebounce } from "./useDebounce";
+export { useClickOutside } from "./useClickOutside";

--- a/src/hooks/common/useClickOutside.ts
+++ b/src/hooks/common/useClickOutside.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+/**
+ * 바깥 클릭 감지 훅 — ref 요소 바깥을 클릭하면 handler 실행.
+ *
+ * 왜 쓰나: 드롭다운·팝오버·메뉴를 "바깥 누르면 닫기".
+ * 팁: handler는 매 렌더 새로 만들면 effect가 재등록되니, 필요시 useCallback으로 감싸기.
+ *
+ * @example
+ * const ref = useClickOutside<HTMLDivElement>(() => setOpen(false));
+ * <div ref={ref}>...드롭다운 내용...</div>
+ */
+export function useClickOutside<T extends HTMLElement = HTMLElement>(
+  handler: () => void,
+) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    const onDown = (e: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) handler();
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("touchstart", onDown);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("touchstart", onDown);
+    };
+  }, [handler]);
+  return ref;
+}

--- a/src/hooks/common/useDebounce.ts
+++ b/src/hooks/common/useDebounce.ts
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useState } from "react";
+
+/**
+ * 디바운스 훅 — 값이 delay(ms) 동안 더 안 바뀌면 그때 반영.
+ *
+ * 왜 쓰나: 검색 입력처럼 타이핑마다 API 치면 과하니, "멈추면 한 번만".
+ *
+ * @example
+ * const [keyword, setKeyword] = useState("");
+ * const debounced = useDebounce(keyword, 300);
+ * useQuery({ queryKey: ["search", debounced], queryFn: ... }); // debounced로 조회
+ */
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}

--- a/src/hooks/common/useDisclosure.ts
+++ b/src/hooks/common/useDisclosure.ts
@@ -1,0 +1,20 @@
+"use client";
+import { useCallback, useState } from "react";
+
+/**
+ * 열림/닫힘 상태 훅 — 모달·드롭다운·아코디언·바텀시트 등.
+ *
+ * 왜 쓰나: 매번 `useState(false)` + 토글 함수 만들지 말고 이걸로 통일.
+ *
+ * @example
+ * const modal = useDisclosure();
+ * <button onClick={modal.open}>열기</button>
+ * {modal.isOpen && <Modal onClose={modal.close} />}
+ */
+export function useDisclosure(initial = false) {
+  const [isOpen, setIsOpen] = useState(initial);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+  return { isOpen, open, close, toggle, setIsOpen };
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./common";
 export * from "./auth";
 export * from "./user";
 export * from "./mail";

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,23 @@
+import { format, formatDistanceToNow, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+
+/**
+ * 날짜 포맷 — ISO 문자열(서버 응답) 또는 Date → 포맷 문자열.
+ * 왜 쓰나: 컴포넌트마다 date-fns 직접 쓰지 말고 여기로 통일.
+ *
+ * @example formatDate("2026-06-18T10:00:00")        // "2026.06.18"
+ * @example formatDate(d, "yyyy년 M월 d일")            // 패턴 직접 지정
+ */
+export function formatDate(value: string | Date, pattern = "yyyy.MM.dd"): string {
+  const date = typeof value === "string" ? parseISO(value) : value;
+  return format(date, pattern, { locale: ko });
+}
+
+/**
+ * 상대 시간 — "3시간 전", "2일 전" 형태.
+ * @example formatRelativeTime("2026-06-18T07:00:00") // "5시간 전"
+ */
+export function formatRelativeTime(value: string | Date): string {
+  const date = typeof value === "string" ? parseISO(value) : value;
+  return formatDistanceToNow(date, { addSuffix: true, locale: ko });
+}


### PR DESCRIPTION
멘티가 새로 만들기 전 갖다 쓰도록 공통 자산 정리.
- 훅: useDisclosure(모달/드롭다운), useDebounce(검색), useClickOutside(드롭다운 닫기) — `@/hooks`
- 유틸: lib/date.ts(formatDate·formatRelativeTime) — `@/lib/date`
- docs/toolbox.md: 공통 컴포넌트·훅·유틸 카탈로그(뭐냐/언제/예시)
- 각 파일 JSDoc로 설명 (멘티용)

build·lint 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 공통 자산 카탈로그 규칙, 기존 훅/유틸/컴포넌트 목록 및 추가 가이드 문서 제공

* **New Features**
  * 팝업·드롭다운·아코디언 상태 관리 훅 추가
  * 입력값 디바운싱 훅 추가
  * 요소 외부 클릭 감지 훅 추가
  * 한국어 기반 날짜 포맷팅 및 상대 시간 표시 유틸리티 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->