### PR TITLE
[Fix] 헤더 방어로직 추가 + 보고서 페이지 버튼 위치 수정

### DIFF
--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
-import { Sparkles, Search } from "lucide-react";
+import { Sparkles, Search, Upload } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import RequireMember from "@/components/auth/RequireMember";
@@ -89,9 +89,18 @@ export default function ReportPage() {
     <RequireMember>
       <main className="min-h-screen pb-16 bg-white">
         <div className="container-x-lg">
-          <div className="pt-6 lg:pt-16 pb-6">
-            <h1 className="text-h1 text-gray-900 mb-2">내 보고서</h1>
-            <p className="text-base text-gray-600">본인이 속한 스터디·멤버가 작성한 보고서만 조회됩니다.</p>
+          <div className="flex items-start justify-between gap-4 pt-6 lg:pt-16 pb-10">
+            <div>
+              <h1 className="text-h1 text-gray-900 mb-2">내 보고서</h1>
+              <p className="text-base text-gray-600">본인이 속한 스터디·멤버가 작성한 보고서만 조회됩니다.</p>
+            </div>
+            <button
+              onClick={() => router.push("/report/write")}
+              className="px-6 py-3 bg-gray-800 text-white rounded-2xl font-medium text-base hover:bg-[#3E434A]/90 transition-colors flex items-center gap-4 shrink-0 whitespace-nowrap tracking-wide"
+            >
+              <Upload size={18} />
+              새 보고서 업로드
+            </button>
           </div>
 
           {groupsLoading && (
@@ -121,16 +130,6 @@ export default function ReportPage() {
           {/* 그룹 있음 — 보고서 뷰 */}
           {!groupsLoading && !isError && allGroups.length > 0 && (
             <>
-              {/* 업로드 버튼 */}
-              <div className="flex justify-end mb-6">
-                <button
-                  onClick={() => router.push("/report/write")}
-                  className="px-5 py-2.5 bg-gray-900 text-white rounded-lg font-medium text-sm hover:bg-gray-700 transition-colors shrink-0"
-                >
-                  + 새 보고서 업로드
-                </button>
-              </div>
-
               {/* 필터: 그룹 탭 + 검색 */}
               <div className="rounded-xl border border-gray-200 bg-white p-4 mb-6 space-y-3">
                 <div className="flex items-center gap-3 flex-wrap">

--- a/src/components/manage/ReportManageSection.tsx
+++ b/src/components/manage/ReportManageSection.tsx
@@ -90,7 +90,7 @@ export default function ReportManageSection() {
     <div className="max-w-6xl mx-auto">
 
       {/* 헤더: 제목 + 업로드 버튼 */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-10">
         <h1 className="text-h1 text-gray-900">전체 보고서 관리</h1>
         <button
           onClick={() => router.push("/report/write")}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -161,10 +161,12 @@ export default function Header() {
               );
             })}
           </ul>
-          {/* 전체폭 셸프 — 카테고리 hover 시 헤더가 통째로 펼쳐지는 배경 */}
+          {/* 전체폭 셸프 — 카테고리 hover/focus 시 헤더가 통째로 펼쳐지는 배경.
+              드롭다운(글자)이 focus-within으로도 열리므로 배경도 동일 조건을 줘야
+              "배경 없이 글자만 남는" 현상이 안 생김 (방어로직) */}
           <div
             aria-hidden="true"
-            className={`invisible opacity-0 group-hover/cats:visible group-hover/cats:opacity-100 absolute inset-x-0 top-full z-30 h-44 border-b transition-opacity ${
+            className={`invisible opacity-0 group-hover/cats:visible group-hover/cats:opacity-100 group-focus-within/cats:visible group-focus-within/cats:opacity-100 absolute inset-x-0 top-full z-30 h-44 border-b transition-opacity ${
               isHome ? "bg-[#151517] border-white/10" : "bg-gray-0 border-gray-200"
             }`}
           />


### PR DESCRIPTION
/report — 내 보고서 (업로드 버튼 교체·이동)
/manage — 전체 보고서 관리 (참고할 버튼 원본)
공용 헤더 컴포넌트 (src/components/shared/Header.tsx 등) — 호버 드롭다운

보고서 업로드 버튼 교체 + 위치 변경
/report의 "새 보고서 업로드" 버튼을 /manage의 버튼 스타일(연필 아이콘 포함)로 교체 위치를 제목 "내 보고서" 줄 우측 끝으로 이동
2. 헤더 호버 드롭다운 배경 누락 버그 방어로직

헤더 nav 호버 시 배경 없이 글자만 보이는 경우 발생 → 원인 파악
호버 시 드롭다운 컨테이너 + 배경이 항상 표시되도록 방어로직/디버깅

## 🔗 관련 이슈                                                                                                                                
Closes #194 

## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✨ 추가/수정 내용


## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 보고서 페이지의 “새 보고서 업로드” 버튼이 상단 헤더로 이동해 더 눈에 띄게 표시됩니다.
  * 업로드 버튼에 아이콘이 추가되고, 더 큰 버튼 스타일로 개선되었습니다.
* **Bug Fixes**
  * 카테고리 드롭다운에 포커스가 이동해도 헤더 배경이 함께 유지되도록 수정했습니다.
* **Style**
  * 보고서 관리 영역의 헤더와 필터 사이 간격을 조정해 화면 구성이 더 여유 있어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->