### PR TITLE
[Hotfix] 댓글/대댓글 수정 인라인 전환 (window.prompt 제거)

### DIFF
--- a/src/app/coding-test/[id]/page.tsx
+++ b/src/app/coding-test/[id]/page.tsx
@@ -11,22 +11,7 @@ import { useMe } from "@/hooks/auth";
 import RequireMember from "@/components/auth/RequireMember";
 import { codingTestApi } from "@/api";
 import { useCodingTestMeta } from "@/hooks/coding-test/useCodingTestMeta";
-import {
-  useProblemComments,
-  type NormalizedComment,
-} from "@/hooks/coding-test/useProblemComments";
-
-function findCommentById(
-  list: NormalizedComment[],
-  id: number,
-): NormalizedComment | null {
-  for (const c of list) {
-    if (c.id === id) return c;
-    const found = findCommentById(c.replies, id);
-    if (found) return found;
-  }
-  return null;
-}
+import { useProblemComments } from "@/hooks/coding-test/useProblemComments";
 
 function formatDate(iso?: string): string {
   if (!iso) return "";
@@ -280,15 +265,8 @@ export default function CodingTestDetailPage() {
                         date={c.date}
                         replies={c.replies}
                         onReplySubmit={replyComment}
-                        onEditComment={async (commentId) => {
-                          const comment = findCommentById(comments, commentId);
-                          const current = comment?.content ?? "";
-                          const newContent = window.prompt(
-                            "수정할 내용을 입력하세요.",
-                            current,
-                          );
-                          if (newContent != null && newContent.trim())
-                            await updateComment(commentId, newContent.trim());
+                        onEditComment={async (commentId, newContent) => {
+                          await updateComment(commentId, newContent);
                         }}
                         onDeleteComment={async (commentId) => {
                           if (window.confirm("이 댓글을 삭제할까요?"))

--- a/src/components/detail/CommentSection.tsx
+++ b/src/components/detail/CommentSection.tsx
@@ -137,6 +137,8 @@ export const CommentItem = ({
   const [replyValue, setReplyValue] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const isLoggedIn = currentUserId != null;
   const isMine = isLoggedIn && userId != null && currentUserId === userId;
@@ -184,30 +186,37 @@ export const CommentItem = ({
                 <div className="absolute right-0 top-full mt-1 min-w-[160px] py-1 bg-white rounded-xl border border-gray-200 shadow-lg z-50">
                   {isMine ? (
                     <>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setEditValue(content);
-                          setIsEditing(true);
-                          setMenuOpen(false);
-                        }}
-                        className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-sm font-medium text-gray-700 hover:bg-gray-50"
-                      >
-                        <Pencil size={18} className="shrink-0 text-gray-500" />
-                        수정
-                      </button>
-                      <div className="border-t border-gray-100 my-1" />
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onDeleteComment?.(id);
-                          setMenuOpen(false);
-                        }}
-                        className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-sm font-medium text-red-600 hover:bg-red-50"
-                      >
-                        <Trash2 size={18} className="shrink-0" />
-                        삭제
-                      </button>
+                      {canEdit && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setEditValue(content);
+                            setEditError(null);
+                            setIsEditing(true);
+                            setMenuOpen(false);
+                          }}
+                          className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-sm font-medium text-gray-700 hover:bg-gray-50"
+                        >
+                          <Pencil size={18} className="shrink-0 text-gray-500" />
+                          수정
+                        </button>
+                      )}
+                      {canEdit && canDelete && (
+                        <div className="border-t border-gray-100 my-1" />
+                      )}
+                      {canDelete && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onDeleteComment?.(id);
+                            setMenuOpen(false);
+                          }}
+                          className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-sm font-medium text-red-600 hover:bg-red-50"
+                        >
+                          <Trash2 size={18} className="shrink-0" />
+                          삭제
+                        </button>
+                      )}
                     </>
                   ) : (
                     <button
@@ -238,29 +247,42 @@ export const CommentItem = ({
               aria-label="댓글 수정"
               className="w-full resize-none rounded-[12px] border-2 border-gray-300 p-3 text-gray-900 text-[15px] font-medium leading-relaxed outline-none focus:border-gray-400"
             />
+            {editError && (
+              <p className="text-sm font-medium text-danger">{editError}</p>
+            )}
             <div className="self-end flex gap-2">
               <button
                 type="button"
+                disabled={isSaving}
                 onClick={() => {
                   setIsEditing(false);
                   setEditValue(content);
+                  setEditError(null);
                 }}
-                className="px-4 py-1.5 rounded-full border border-gray-300 text-gray-600 text-sm font-semibold hover:bg-gray-50 transition-colors"
+                className="px-4 py-1.5 rounded-full border border-gray-300 text-gray-600 text-sm font-semibold hover:bg-gray-50 transition-colors disabled:opacity-60"
               >
                 취소
               </button>
               <button
                 type="button"
-                disabled={disabled || !editValue.trim()}
+                disabled={disabled || isSaving || !editValue.trim()}
                 onClick={async () => {
                   const v = editValue.trim();
-                  if (!v) return;
-                  await onEditComment?.(id, v);
-                  setIsEditing(false);
+                  if (!v || !onEditComment || isSaving) return;
+                  setIsSaving(true);
+                  setEditError(null);
+                  try {
+                    await onEditComment(id, v);
+                    setIsEditing(false);
+                  } catch {
+                    setEditError("댓글 수정에 실패했어요. 다시 시도해 주세요.");
+                  } finally {
+                    setIsSaving(false);
+                  }
                 }}
                 className="px-4 py-1.5 rounded-full bg-[#3E434A] text-white text-sm font-semibold hover:bg-gray-700 transition-colors disabled:opacity-60"
               >
-                저장
+                {isSaving ? "저장 중..." : "저장"}
               </button>
             </div>
           </div>

--- a/src/components/detail/CommentSection.tsx
+++ b/src/components/detail/CommentSection.tsx
@@ -102,7 +102,7 @@ interface CommentItemProps {
   depth?: number;
   replies?: ReplyData[];
   onReplySubmit?: (parentId: number, content: string) => void;
-  onEditComment?: (id: number) => void;
+  onEditComment?: (id: number, content: string) => void | Promise<void>;
   onDeleteComment?: (id: number) => void;
   onReportComment?: (id: number) => void;
   disabled?: boolean;
@@ -135,6 +135,8 @@ export const CommentItem = ({
   const [replyOpen, setReplyOpen] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [replyValue, setReplyValue] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(content);
   const menuRef = useRef<HTMLDivElement>(null);
   const isLoggedIn = currentUserId != null;
   const isMine = isLoggedIn && userId != null && currentUserId === userId;
@@ -185,7 +187,8 @@ export const CommentItem = ({
                       <button
                         type="button"
                         onClick={() => {
-                          onEditComment?.(id);
+                          setEditValue(content);
+                          setIsEditing(true);
                           setMenuOpen(false);
                         }}
                         className="flex items-center gap-3 w-full px-4 py-2.5 text-left text-sm font-medium text-gray-700 hover:bg-gray-50"
@@ -225,9 +228,47 @@ export const CommentItem = ({
           )}
         </div>
 
-        <p className="text-gray-900 text-[15px] font-medium mb-4 leading-relaxed">
-          {content}
-        </p>
+        {isEditing ? (
+          <div className="mb-4 flex flex-col gap-2">
+            <textarea
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              autoFocus
+              rows={3}
+              aria-label="댓글 수정"
+              className="w-full resize-none rounded-[12px] border-2 border-gray-300 p-3 text-gray-900 text-[15px] font-medium leading-relaxed outline-none focus:border-gray-400"
+            />
+            <div className="self-end flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setIsEditing(false);
+                  setEditValue(content);
+                }}
+                className="px-4 py-1.5 rounded-full border border-gray-300 text-gray-600 text-sm font-semibold hover:bg-gray-50 transition-colors"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                disabled={disabled || !editValue.trim()}
+                onClick={async () => {
+                  const v = editValue.trim();
+                  if (!v) return;
+                  await onEditComment?.(id, v);
+                  setIsEditing(false);
+                }}
+                className="px-4 py-1.5 rounded-full bg-[#3E434A] text-white text-sm font-semibold hover:bg-gray-700 transition-colors disabled:opacity-60"
+              >
+                저장
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-gray-900 text-[15px] font-medium mb-4 leading-relaxed">
+            {content}
+          </p>
+        )}
 
         <div className="flex items-center gap-4 text-gray-600 text-[15px] font-medium">
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## 무엇을
댓글·대댓글 '수정'을 `window.prompt` 대신 **그 자리 인라인 편집**(textarea + 저장/취소)으로 전환.

## 왜 이 방식으로
prompt는 멀티라인·UX가 빈약하고 모바일/일관성에 안 맞음. CommentItem이 자체 편집 상태(`isEditing`)를 갖고, `onEditComment(id, content)`로 새 내용만 부모에 넘겨 저장(코딩테스트는 기존 `updateComment` 그대로 사용). 댓글·대댓글 공통 적용.

## 어떻게 테스트했는지
`npm run build` 통과, lint 0 error. 로컬에서 '수정' → 인라인 textarea 전환 → 저장/취소 동작 시각 확인. (사용 중인 소비처는 코딩테스트 상세 1곳, mock 게시판에서 UI 토글 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 댓글 수정이 즉시 실행 방식에서 인라인 편집 방식으로 바뀌어, 댓글 본문을 직접 수정한 뒤 저장할 수 있습니다.
  * 수정 시 입력한 내용이 그대로 반영되며, 편집 완료 후 자동으로 편집 모드가 종료됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->