### PR TITLE
feat: 타입세이프 환경변수 로더 (src/lib/env.ts)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,10 +1,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
+import { publicEnv } from "@/lib/env";
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL &&
-  process.env.NEXT_PUBLIC_API_URL !== "undefined"
-    ? process.env.NEXT_PUBLIC_API_URL
-    : "/api/v1";
+const API_BASE_URL = publicEnv.apiUrl ?? "/api/v1";
 
 const REFRESH_PATH = "/login/refresh";
 const LOGIN_REDIRECT_PATH = "/login";

--- a/src/api/image.api.ts
+++ b/src/api/image.api.ts
@@ -5,10 +5,11 @@
  */
 import axios from "axios";
 import { attachAuthInterceptor } from "./client";
+import { publicEnv } from "@/lib/env";
 
 const getImageBaseUrl = () => {
-  const base = process.env.NEXT_PUBLIC_API_URL;
-  if (base && base !== "undefined" && base.endsWith("/api/v1")) {
+  const base = publicEnv.apiUrl;
+  if (base && base.endsWith("/api/v1")) {
     return base.replace(/\/api\/v1$/, "");
   }
   return "";

--- a/src/app/api/v1/[...path]/route.ts
+++ b/src/app/api/v1/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { serverEnv } from "@/lib/env";
 
-const BACKEND = (process.env.BACKEND_URL ?? "").replace(/\/$/, "");
+const BACKEND = serverEnv.backendUrl;
 
 async function proxy(req: NextRequest) {
   if (!BACKEND) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,25 @@
+/**
+ * 타입세이프 환경변수 로더.
+ *
+ * - `publicEnv` : 클라이언트/서버 공용 (NEXT_PUBLIC_* — 빌드 타임 인라인)
+ * - `serverEnv` : **서버 전용** (BFF 라우트 핸들러에서만). 클라이언트 컴포넌트에서 import 금지.
+ *
+ * 환경변수 직접 참조(process.env.X)를 한곳으로 모아 오타·미설정을 빨리 드러내고
+ * "undefined" 문자열 같은 엣지 케이스를 일관되게 처리한다.
+ */
+
+// NEXT_PUBLIC_API_URL 정규화 — 미설정이거나 문자열 "undefined"면 null(=BFF 프록시 사용)
+const rawApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = rawApiUrl && rawApiUrl !== "undefined" ? rawApiUrl : null;
+
+export const publicEnv = {
+  /** 외부 API 베이스 URL. null이면 같은 오리진의 BFF 프록시(`/api/v1`)를 사용한다. */
+  apiUrl,
+} as const;
+
+export const serverEnv = {
+  /** BFF가 프록시할 백엔드 주소(서버 전용). 미설정이면 빈 문자열. 끝 슬래시 제거. */
+  get backendUrl(): string {
+    return (process.env.BACKEND_URL ?? "").replace(/\/$/, "");
+  },
+} as const;


### PR DESCRIPTION
## 무엇을
환경변수 접근을 `src/lib/env.ts`로 중앙화 (publicEnv / serverEnv).

## 왜 이 방식으로
`process.env.*` 산재 → 오타·미설정·"undefined" 문자열 엣지케이스가 곳곳에 중복. 한곳에 모아 타입과 정규화 규칙을 일원화. NEXT_PUBLIC(빌드 인라인)과 서버 전용(BACKEND_URL)을 명확히 분리(serverEnv는 클라이언트 import 금지).

## 어떻게 테스트했는지
`npm run build`·lint 통과. client.ts·image.api.ts·route.ts의 기존 분기 로직을 **동작 동일**하게 env 로더 경유로만 교체(값/폴백 변화 없음). 직접 참조는 env.ts 한 곳만 남음.

## 연관 이슈
- Closes #96 (환경변수 타입세이프 로더)