### PR TITLE
refactor: Skeleton 자리표시자 + 로딩 패턴 정리

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -18,5 +18,3 @@ export default function LoadingSpinner({
     />
   );
 }
-
-// 주석 테스트

--- a/src/components/common/Skeleton.stories.tsx
+++ b/src/components/common/Skeleton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Skeleton, SkeletonText } from "./Skeleton";
+
+const meta = {
+  title: "Common/Skeleton",
+  component: Skeleton,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "콘텐츠 로딩 자리표시자(회색 펄스). 크기는 className으로 지정. 버튼/인라인 로딩은 LoadingSpinner 사용.",
+      },
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const 기본: Story = { args: { className: "h-4 w-48" } };
+
+export const 텍스트: Story = {
+  render: () => <SkeletonText lines={3} className="w-80" />,
+};
+
+export const 카드: Story = {
+  render: () => (
+    <div className="flex w-80 flex-col gap-4 rounded-2xl border border-gray-200 p-6">
+      <Skeleton className="h-32 w-full rounded-xl" />
+      <Skeleton className="h-5 w-2/3" />
+      <SkeletonText lines={2} />
+    </div>
+  ),
+};

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * @file Skeleton.tsx
+ * @description 콘텐츠 로딩 자리표시자 (회색 펄스 블록).
+ *
+ * 역할 구분:
+ * - **Skeleton** : 데이터 로드 전 레이아웃 자리를 잡는 자리표시자(목록·카드·상세 등).
+ * - **LoadingSpinner** : 버튼/인라인 등 짧은 동작 중 표시(제출 중 등).
+ */
+
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+/** 기본 자리표시자 — 크기는 className(h-4, w-1/2 등)으로 지정. */
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-md bg-gray-100", className)}
+      {...props}
+    />
+  );
+}
+
+/** 여러 줄 텍스트 자리표시자 (마지막 줄은 짧게). */
+export function SkeletonText({
+  lines = 3,
+  className,
+}: {
+  lines?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton
+          key={`line-${i}`}
+          className={cn("h-4", i === lines - 1 && "w-2/3")}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 무엇을
Skeleton 자리표시자 컴포넌트 추가 + 로딩 UI 역할 정리.

## 왜 이 방식으로
콘텐츠 로딩 자리를 잡는 Skeleton이 없어 화면마다 임시 처리. `Skeleton`/`SkeletonText` 프리미티브를 만들고 역할을 명확히 분리 — **Skeleton**=목록/카드/상세 자리표시, **LoadingSpinner**=버튼/인라인 동작. 스토리북에 사용 예시 추가.

## 어떻게 테스트했는지
`npm run build`·lint 통과, Storybook 빌드 대상 스토리 추가. (도입은 각 화면에서 점진 적용)

## 연관 이슈
- Closes #94 (LoadingSpinner / Skeleton 패턴 정리)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 로딩 중 화면을 위한 자리표시자 컴포넌트가 추가되었습니다.
  * 여러 줄 텍스트 형태의 로딩 표시와 카드형 예시를 포함한 스토리북 문서가 추가되었습니다.
* **Bug Fixes**
  * 스피너 컴포넌트에 남아 있던 테스트용 주석이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->