### PR TITLE
refactor: 미사용 jotai 제거 + 상태 관리 가이드 문서화

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,21 +28,22 @@ src/
 
 ## 최상위 폴더 역할
 
-| 폴더 | 역할 |
-|---|---|
-| `app/` | Next.js 라우팅. 각 라우트의 `page.tsx`는 **얇게** 두고 인증가드 + `*PageClient`/`Section`에 위임. 데이터 패칭은 페이지에서 하지 않음 |
-| `api/` | 서버 통신. `client.ts`(axios+인터셉터) + 도메인별 `*.api.ts`. 앱은 `@/api` 배럴에서만 import |
-| `hooks/` | 도메인별 폴더. TanStack Query 래핑 훅(서버 상태) + 폼/인증 로직 훅 |
-| `store/` | Zustand 전역 상태(`userStore` 등). 셀렉터로 필요한 필드만 구독 |
-| `components/` | UI. 역할/도메인별 폴더. ui/common/shared 구분 → components.md |
-| `lib/` | 순수 유틸(`cn()` 등). 부수효과 없는 함수만 |
-| `styles/` | 색 팔레트 등 보조 상수. 토큰 정본은 `globals.css` |
+| 폴더          | 역할                                                                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `app/`        | Next.js 라우팅. 각 라우트의 `page.tsx`는 **얇게** 두고 인증가드 + `*PageClient`/`Section`에 위임. 데이터 패칭은 페이지에서 하지 않음 |
+| `api/`        | 서버 통신. `client.ts`(axios+인터셉터) + 도메인별 `*.api.ts`. 앱은 `@/api` 배럴에서만 import                                         |
+| `hooks/`      | 도메인별 폴더. TanStack Query 래핑 훅(서버 상태) + 폼/인증 로직 훅                                                                   |
+| `store/`      | Zustand 전역 상태(`userStore` 등). 셀렉터로 필요한 필드만 구독                                                                       |
+| `components/` | UI. 역할/도메인별 폴더. ui/common/shared 구분 → components.md                                                                        |
+| `lib/`        | 순수 유틸(`cn()` 등). 부수효과 없는 함수만                                                                                           |
+| `styles/`     | 색 팔레트 등 보조 상수. 토큰 정본은 `globals.css`                                                                                    |
 
 ### `src/store` 상세
-| 스토어 | 역할 |
-|---|---|
-| `userStore.ts` | 인증/프로필 상태 + `localStorage` persist(SSR-safe 스냅샷). 액션: `setUser/setAuthStatus/updateEmail/clearUser` |
-| `codingTestMetaStore.ts` | 코테 필터 메타(플랫폼/언어/카테고리) |
+
+| 스토어                   | 역할                                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `userStore.ts`           | 인증/프로필 상태 + `localStorage` persist(SSR-safe 스냅샷). 액션: `setUser/setAuthStatus/updateEmail/clearUser` |
+| `codingTestMetaStore.ts` | 코테 필터 메타(플랫폼/언어/카테고리)                                                                            |
 
 사용: `useUserStore((s) => s.name)`처럼 **셀렉터로 필요한 필드만** 구독(전체 구독 금지 — 불필요 리렌더).
 
@@ -65,13 +66,33 @@ api  ←  hooks  ←  components / app
 
 ## 새 파일 어디에 둘까
 
-| 만들 것 | 위치 |
-|---|---|
-| 새 페이지 | `app/<route>/page.tsx` (얇게) + 필요시 `components/<도메인>/<X>PageClient.tsx` |
-| 도메인 API | `api/<도메인>.api.ts` + `api/index.ts`에 배럴 추가 → [api.md](./api.md) |
-| 서버 상태 훅 | `hooks/<도메인>/useXxx.ts` |
-| 전역 상태 | `store/xxxStore.ts` |
-| 컴포넌트 | 역할에 따라 `components/...` → [components.md](./components.md) |
-| 순수 유틸 | `lib/` |
+| 만들 것      | 위치                                                                           |
+| ------------ | ------------------------------------------------------------------------------ |
+| 새 페이지    | `app/<route>/page.tsx` (얇게) + 필요시 `components/<도메인>/<X>PageClient.tsx` |
+| 도메인 API   | `api/<도메인>.api.ts` + `api/index.ts`에 배럴 추가 → [api.md](./api.md)        |
+| 서버 상태 훅 | `hooks/<도메인>/useXxx.ts`                                                     |
+| 전역 상태    | `store/xxxStore.ts`                                                            |
+| 컴포넌트     | 역할에 따라 `components/...` → [components.md](./components.md)                |
+| 순수 유틸    | `lib/`                                                                         |
 
 > 애매하면 "이게 통신인가(api) / 상태·로직인가(hooks·store) / 보이는 것인가(components)"로 판단.
+
+---
+
+## 상태 관리 — 무엇을 어디에 둘까
+
+상태 라이브러리는 **2종**만 쓴다. (Jotai는 미사용 → 제거됨)
+
+| 종류                        | 도구                   | 예시                                                                                                   |
+| --------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| **서버 상태** (서버가 정본) | **TanStack Query**     | 게시글 목록/상세, 뮤테이션, 사용자 정보 패칭. `hooks/<도메인>/useXxx.ts`로 래핑                        |
+| **전역 클라이언트 상태**    | **Zustand** (`store/`) | 로그인 사용자 신원(`userStore`), 화면 간 공유 메타(`codingTestMetaStore`). 셀렉터로 필요한 필드만 구독 |
+| **로컬 UI 상태**            | `useState`             | 모달 열림, 입력값, 탭 선택 등 한 컴포넌트 안에서만 쓰는 것                                             |
+
+판단 기준:
+
+- 서버에서 온/서버가 정본인 데이터 → **React Query** (store에 복사 금지 = 중복 상태 원인)
+- 여러 화면이 공유하는 클라 상태 → **Zustand store**
+- 한 컴포넌트 안에서만 → **useState**
+
+> ⚠️ 같은 값을 React Query와 store 양쪽에 두지 않는다. 서버 데이터는 React Query가 정본, store엔 식별자/파생 플래그(예: `userId`·`role`)만.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
-        "jotai": "^2.20.1",
         "lucide-react": "^0.577.0",
         "next": "^16.2.9",
         "radix-ui": "^1.6.0",
@@ -102,7 +101,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -117,7 +116,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -127,7 +126,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -158,7 +157,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -188,7 +187,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -227,7 +226,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -251,7 +250,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -265,7 +264,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -338,7 +337,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -348,7 +347,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -358,7 +357,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -368,7 +367,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -382,7 +381,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -498,7 +497,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -513,7 +512,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -532,7 +531,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -2097,7 +2096,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2108,7 +2107,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2119,7 +2118,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2129,14 +2128,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7805,7 +7804,7 @@
       "version": "4.27.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
       "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8357,7 +8356,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -8848,7 +8847,7 @@
       "version": "1.5.244",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
       "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -9151,7 +9150,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10215,7 +10214,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11584,40 +11583,11 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/jotai": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.1.tgz",
-      "integrity": "sha512-dnuKfU/GLi8B28RRMjQ3AfoN7kfzP8o41+AX2FmITZqEMY8PHnjABq+VkEooomLwYaGjda+pgy0yFSjaHX/ZPg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0",
-        "@babel/template": ">=7.0.0",
-        "@types/react": ">=17.0.0",
-        "react": ">=17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@babel/template": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11647,7 +11617,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11702,7 +11672,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -12332,7 +12302,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -13696,7 +13666,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/npm-run-path": {
@@ -15387,7 +15357,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17136,7 +17106,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
       "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17856,7 +17826,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
-    "jotai": "^2.20.1",
     "lucide-react": "^0.577.0",
     "next": "^16.2.9",
     "radix-ui": "^1.6.0",


### PR DESCRIPTION
## 무엇을
유령 의존성 `jotai` 제거 + 상태 관리 기준 문서화.

## 왜 이 방식으로
감사 결과 **jotai는 src 어디서도 import 0건**(설치만 됨). 실제 상태관리는 이미 React Query(서버) + Zustand(전역 클라, `userStore`·`codingTestMetaStore`)로 분리돼 있어 "섞임"은 죽은 의존성 때문이었음 → 제거로 단일화. 멘티 혼란 방지를 위해 docs/architecture.md에 "무엇을 어디에 둘까" 가이드 추가.

## 어떻게 테스트했는지
`npm run build` 통과(jotai 미참조라 영향 없음). lint 통과.

## 연관 이슈
- Closes #105 (상태 관리 정리 — Jotai vs Zustand)

> 참고: docs/architecture.md가 prettier로 일부 재정렬됨(표 정렬). 내용 변경은 "상태 관리" 섹션 추가 + jotai 미사용 명시.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 폴더 구조와 역할 안내를 더 보기 쉬운 표 형태로 정리했습니다.
  * 새 파일을 어디에 둘지, 상태를 어떤 방식으로 관리할지에 대한 기준을 추가했습니다.
  * 서버 상태, 전역 클라이언트 상태, 로컬 UI 상태의 구분 기준을 명확히 했습니다.
  * 동일한 데이터를 여러 상태 저장소에 중복하지 않는 권장 사항을 문서에 반영했습니다.

* **Chores**
  * 불필요한 의존성을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->