### PR TITLE
fix: 공지·뉴스레터 백엔드 사양 반영 + 수정 버그 해결

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -110,6 +110,7 @@ export { applyApi, type ApplicationRequest } from "./apply.api";
 export {
   newsApi,
   type NewsCategory,
+  type NewsletterType,
   type NewsListParams,
   type NewsListItem,
   type NewsListResponse,

--- a/src/api/news.api.ts
+++ b/src/api/news.api.ts
@@ -3,8 +3,13 @@ import { type ApiEnvelope } from "./auth.api";
 
 export type NewsCategory = "NOTICE" | "EVENT" | "NEWSLETTER" | "IT_NEWS";
 
+export type NewsletterType = "WEEKLY" | "SPECIAL" | "NOTICE";
+
+// TODO(백엔드): GET /api/v1/news에 newsletterType 쿼리 파라미터(복수 지원) 추가 요청됨.
+// 추가되면 NewsListParams에 newsletterType?: NewsletterType | NewsletterType[] 필드 추가하고
+// getList 호출부(useNewsList, news/page.tsx)에서 서버 필터링으로 전환할 것.
 export type NewsListParams = {
-  category?: NewsCategory;
+  category?: NewsCategory | NewsCategory[];
   keyword?: string;
   page?: number;
   size?: number;
@@ -17,6 +22,7 @@ export type NewsListItem = {
   authorId: number;
   title: string;
   category: NewsCategory;
+  newsletterType?: NewsletterType;
   createdAt: string;
   viewCount: number;
   pinned: boolean;
@@ -56,6 +62,7 @@ export type NewsDetail = {
   authorId: number;
   title: string;
   category: NewsCategory;
+  newsletterType?: NewsletterType;
   content: string;
   createdAt: string;
   updatedAt: string;
@@ -68,12 +75,14 @@ export type NewsCreateBody = {
   title: string;
   content: string;
   category?: NewsCategory;
+  newsletterType?: NewsletterType;
 };
 
 export type NewsUpdateBody = {
   title?: string;
   content?: string;
   category?: NewsCategory;
+  newsletterType?: NewsletterType;
 };
 
 export type AttachmentDownload = {
@@ -83,7 +92,10 @@ export type AttachmentDownload = {
 
 export const newsApi = {
   getList: (params: NewsListParams) =>
-    api.get<ApiEnvelope<NewsListResponse>>("/news", { params }),
+    api.get<ApiEnvelope<NewsListResponse>>("/news", {
+      params,
+      paramsSerializer: { indexes: null },
+    }),
 
   getById: (id: number) =>
     api.get<ApiEnvelope<NewsDetail>>(`/news/${id}`),

--- a/src/api/report.api.ts
+++ b/src/api/report.api.ts
@@ -4,6 +4,9 @@
  */
 import { api } from "./client";
 
+// TODO(백엔드): GET /report에 그룹(팀) 필터 파라미터(예: groupId) 추가 요청됨.
+// 추가되면 ReportListParams에 groupId?: number | number[] 필드 추가하고
+// ReportManageSection.tsx의 클라이언트 그룹핑("팀으로 그룹핑")을 서버 필터로 전환할 것.
 export type ReportListParams = {
   page?: number;
   size?: number;

--- a/src/api/report.api.ts
+++ b/src/api/report.api.ts
@@ -4,9 +4,6 @@
  */
 import { api } from "./client";
 
-// TODO(백엔드): GET /report에 그룹(팀) 필터 파라미터(예: groupId) 추가 요청됨.
-// 추가되면 ReportListParams에 groupId?: number | number[] 필드 추가하고
-// ReportManageSection.tsx의 클라이언트 그룹핑("팀으로 그룹핑")을 서버 필터로 전환할 것.
 export type ReportListParams = {
   page?: number;
   size?: number;
@@ -15,6 +12,8 @@ export type ReportListParams = {
   endDate?: string;
   /** 검색어 (제목·작성자명) */
   keyword?: string;
+  /** 그룹 ID 필터 (복수 OR 조건, 미지정 시 전체) */
+  groupIds?: number[];
 };
 
 /** GET /report, /report/group/{groupId} 응답의 보고서 미리보기 한 건 */

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -10,9 +10,23 @@ import SearchBar from "@/components/common/SearchBar";
 import { useIsStaff } from "@/hooks/auth/useIsStaff";
 import { useNewsList } from "@/hooks/news/useNewsList";
 import { formatDate } from "@/lib/date";
+import type { NewsletterType } from "@/api";
 
-const CATEGORY_TABS = ["전체", "주간", "특집"] as const;
+const CATEGORY_TABS = ["전체", "주간", "특집", "공지"] as const;
 type CategoryTab = (typeof CATEGORY_TABS)[number];
+
+const TAB_TO_TYPE: Record<CategoryTab, NewsletterType | undefined> = {
+  전체: undefined,
+  주간: "WEEKLY",
+  특집: "SPECIAL",
+  공지: "NOTICE",
+};
+
+const TYPE_TO_LABEL: Record<NewsletterType, string> = {
+  WEEKLY: "주간",
+  SPECIAL: "특집",
+  NOTICE: "공지",
+};
 
 export default function NewsPage() {
   const isStaff = useIsStaff();
@@ -33,7 +47,15 @@ export default function NewsPage() {
     size: 11,
   });
 
-  const items = data?.content ?? [];
+  // TODO(백엔드): GET /api/v1/news에 newsletterType 쿼리 필터 추가되면 이 클라이언트 필터링 제거하고
+  // useNewsList에 newsletterType 파라미터로 넘겨서 서버 페이지네이션을 그대로 쓰도록 변경할 것.
+  // 현재는 서버가 category=NEWSLETTER 기준으로 11개씩 잘라 보낸 뒤 그 안에서만 주간/특집/공지를 거르므로,
+  // 2페이지 이상에서 결과 누락·totalPages 불일치가 발생할 수 있음.
+  const allItems = data?.content ?? [];
+  const activeType = TAB_TO_TYPE[activeTab];
+  const items = activeType
+    ? allItems.filter((n) => n.newsletterType === activeType)
+    : allItems;
   const totalPages = data?.page?.totalPages
     ? Array.from({ length: data.page.totalPages }, (_, i) => i + 1)
     : [1];
@@ -101,7 +123,7 @@ export default function NewsPage() {
                   className="flex items-center gap-8 px-2 py-6 border-b border-gray-100 transition-colors hover:bg-gray-50"
                 >
                   <span className="w-28 text-center shrink-0 text-sm text-gray-900">
-                    [뉴스레터]
+                    [{news.newsletterType ? TYPE_TO_LABEL[news.newsletterType] : "뉴스레터"}]
                   </span>
                   <span className="flex-1 min-w-0 text-sm text-gray-900">
                     <span className="block truncate">{news.title}</span>

--- a/src/app/news/write/page.tsx
+++ b/src/app/news/write/page.tsx
@@ -1,29 +1,115 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import PostWriteForm from "@/components/board/PostWriteForm";
-import { useNewsCreate } from "@/hooks/news/useNewsMutation";
+import { useNewsCreate, useNewsUpdate } from "@/hooks/news/useNewsMutation";
+import { newsApi, type NewsletterType } from "@/api";
 
-export default function NewsWritePage() {
+const TYPE_MAP: Record<string, NewsletterType> = {
+  주간: "WEEKLY",
+  특집: "SPECIAL",
+  공지: "NOTICE",
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  WEEKLY: "주간",
+  SPECIAL: "특집",
+  NOTICE: "공지",
+};
+
+function NewsWriteClient() {
   const router = useRouter();
-  const { mutateAsync, isPending } = useNewsCreate();
+  const searchParams = useSearchParams();
+  const editId = searchParams.get("edit") ? Number(searchParams.get("edit")) : null;
+
+  const { mutateAsync: createNews, isPending: isCreating } = useNewsCreate();
+  const { mutateAsync: updateNews, isPending: isUpdating } = useNewsUpdate();
+
+  const postQuery = useQuery({
+    queryKey: ["news", editId],
+    queryFn: async () => {
+      const res = await newsApi.getById(editId!);
+      return res.data.data;
+    },
+    enabled: !!editId,
+  });
+
+  const editPost = editId ? postQuery.data : null;
+
+  if (editId && postQuery.isLoading) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+      </main>
+    );
+  }
+
+  if (editId && !postQuery.isLoading && !editPost) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 찾을 수 없습니다.</div>
+      </main>
+    );
+  }
 
   return (
     <PostWriteForm
       boardName="뉴스레터"
-      heading="글 작성"
+      heading={editId ? "글 수정" : "글 작성"}
       categories={["주간", "특집", "공지"]}
       staffOnly
-      backPath="/news"
-      isSubmitting={isPending}
-      onSubmit={async ({ title, content }) => {
+      backPath={editId ? `/news/${editId}` : "/news"}
+      initialValues={
+        editPost
+          ? {
+              title: editPost.title,
+              content: editPost.content,
+              category: editPost.newsletterType ? TYPE_LABEL[editPost.newsletterType] : undefined,
+            }
+          : undefined
+      }
+      isSubmitting={isCreating || isUpdating}
+      onSubmit={async ({ title, content, category }) => {
+        if (!category) {
+          window.alert("분류를 선택해주세요.");
+          return;
+        }
         try {
-          await mutateAsync({ title, content, category: "NEWSLETTER" });
-          router.push("/news");
+          if (editId) {
+            await updateNews({
+              id: editId,
+              data: { title, content, category: "NEWSLETTER", newsletterType: TYPE_MAP[category] },
+            });
+            router.push(`/news/${editId}`);
+          } else {
+            await createNews({
+              title,
+              content,
+              category: "NEWSLETTER",
+              newsletterType: TYPE_MAP[category],
+            });
+            router.push("/news");
+          }
         } catch {
           window.alert("저장에 실패했습니다. 다시 시도해주세요.");
         }
       }}
     />
+  );
+}
+
+export default function NewsWritePage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen bg-white">
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+        </main>
+      }
+    >
+      <NewsWriteClient />
+    </Suspense>
   );
 }

--- a/src/app/news/write/page.tsx
+++ b/src/app/news/write/page.tsx
@@ -46,6 +46,14 @@ function NewsWriteClient() {
     );
   }
 
+  if (editId && postQuery.isError) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 불러오지 못했습니다.</div>
+      </main>
+    );
+  }
+
   if (editId && !postQuery.isLoading && !editPost) {
     return (
       <main className="min-h-screen bg-white">

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -15,11 +15,11 @@ import type { NewsCategory } from "@/api";
 const CATEGORY_TABS = ["전체", "공지", "이벤트", "IT소식"] as const;
 type CategoryTab = (typeof CATEGORY_TABS)[number];
 
-const TAB_TO_CATEGORY: Record<CategoryTab, NewsCategory | undefined> = {
-  전체: undefined,
-  공지: "NOTICE",
-  이벤트: "EVENT",
-  IT소식: "IT_NEWS",
+const TAB_TO_CATEGORY: Record<CategoryTab, NewsCategory[]> = {
+  전체: ["NOTICE", "EVENT", "IT_NEWS"],
+  공지: ["NOTICE"],
+  이벤트: ["EVENT"],
+  IT소식: ["IT_NEWS"],
 };
 
 const CATEGORY_TO_LABEL: Record<string, string> = {
@@ -47,10 +47,7 @@ export default function NoticePage() {
     size: 11,
   });
 
-  const allItems = data?.content ?? [];
-  const items = activeTab === "전체"
-    ? allItems.filter((n) => n.category !== "NEWSLETTER")
-    : allItems;
+  const items = data?.content ?? [];
   const totalPages = data?.page?.totalPages
     ? Array.from({ length: data.page.totalPages }, (_, i) => i + 1)
     : [1];

--- a/src/app/notice/write/page.tsx
+++ b/src/app/notice/write/page.tsx
@@ -46,6 +46,14 @@ function NoticeWriteClient() {
     );
   }
 
+  if (editId && postQuery.isError) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 불러오지 못했습니다.</div>
+      </main>
+    );
+  }
+
   if (editId && !postQuery.isLoading && !editPost) {
     return (
       <main className="min-h-screen bg-white">

--- a/src/app/notice/write/page.tsx
+++ b/src/app/notice/write/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import PostWriteForm from "@/components/board/PostWriteForm";
-import { useNewsCreate } from "@/hooks/news/useNewsMutation";
-import type { NewsCategory } from "@/api";
+import { useNewsCreate, useNewsUpdate } from "@/hooks/news/useNewsMutation";
+import { newsApi, type NewsCategory } from "@/api";
 
 const CATEGORY_MAP: Record<string, NewsCategory> = {
   공지: "NOTICE",
@@ -11,31 +13,92 @@ const CATEGORY_MAP: Record<string, NewsCategory> = {
   IT소식: "IT_NEWS",
 };
 
-export default function NoticeWritePage() {
+const CATEGORY_LABEL: Record<string, string> = {
+  NOTICE: "공지",
+  EVENT: "이벤트",
+  IT_NEWS: "IT소식",
+};
+
+function NoticeWriteClient() {
   const router = useRouter();
-  const { mutateAsync, isPending } = useNewsCreate();
+  const searchParams = useSearchParams();
+  const editId = searchParams.get("edit") ? Number(searchParams.get("edit")) : null;
+
+  const { mutateAsync: createNews, isPending: isCreating } = useNewsCreate();
+  const { mutateAsync: updateNews, isPending: isUpdating } = useNewsUpdate();
+
+  const postQuery = useQuery({
+    queryKey: ["news", editId],
+    queryFn: async () => {
+      const res = await newsApi.getById(editId!);
+      return res.data.data;
+    },
+    enabled: !!editId,
+  });
+
+  const editPost = editId ? postQuery.data : null;
+
+  if (editId && postQuery.isLoading) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+      </main>
+    );
+  }
+
+  if (editId && !postQuery.isLoading && !editPost) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 찾을 수 없습니다.</div>
+      </main>
+    );
+  }
 
   return (
     <PostWriteForm
       boardName="씨부엉 소식"
-      heading="글 작성"
+      heading={editId ? "글 수정" : "글 작성"}
       categories={["공지", "이벤트", "IT소식"]}
       categoryMaxLength={{ 공지: 20000 }}
       staffOnly
-      backPath="/notice"
-      isSubmitting={isPending}
+      backPath={editId ? `/notice/${editId}` : "/notice"}
+      initialValues={
+        editPost
+          ? { title: editPost.title, content: editPost.content, category: CATEGORY_LABEL[editPost.category] }
+          : undefined
+      }
+      isSubmitting={isCreating || isUpdating}
       onSubmit={async ({ title, content, category }) => {
         if (!category) {
           window.alert("분류를 선택해주세요.");
           return;
         }
         try {
-          await mutateAsync({ title, content, category: CATEGORY_MAP[category] });
-          router.push("/notice");
+          if (editId) {
+            await updateNews({ id: editId, data: { title, content, category: CATEGORY_MAP[category] } });
+            router.push(`/notice/${editId}`);
+          } else {
+            await createNews({ title, content, category: CATEGORY_MAP[category] });
+            router.push("/notice");
+          }
         } catch {
           window.alert("저장에 실패했습니다. 다시 시도해주세요.");
         }
       }}
     />
+  );
+}
+
+export default function NoticeWritePage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen bg-white">
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+        </main>
+      }
+    >
+      <NoticeWriteClient />
+    </Suspense>
   );
 }

--- a/src/components/board/PostWriteForm.tsx
+++ b/src/components/board/PostWriteForm.tsx
@@ -35,7 +35,7 @@ type PostWriteFormProps = {
   /** 카테고리별 글자수 제한 오버라이드 (예: { 공지: 20000 }) — 없으면 contentMaxLength 사용 */
   categoryMaxLength?: Record<string, number>;
   /** 수정 모드 초기값 */
-  initialValues?: { title: string; content: string; isAnonymous?: boolean };
+  initialValues?: { title: string; content: string; category?: string; isAnonymous?: boolean };
   /** 게시 버튼 클릭 시 호출 — 미전달 시 backPath로 이동만 */
   onSubmit?: (data: PostWriteSubmitData) => Promise<void>;
   isSubmitting?: boolean;
@@ -64,7 +64,7 @@ export default function PostWriteForm({
   const isStaff = useIsStaff();
   const [title, setTitle] = useState(initialValues?.title ?? "");
   const [content, setContent] = useState(initialValues?.content ?? "");
-  const [category, setCategory] = useState<string | null>(null);
+  const [category, setCategory] = useState<string | null>(initialValues?.category ?? null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [anonymous, setAnonymous] = useState(initialValues?.isAnonymous ?? true);
   const [files, setFiles] = useState<File[]>([]);
@@ -75,9 +75,10 @@ export default function PostWriteForm({
     if (initialValues === undefined) return;
     setTitle(initialValues.title);
     setContent(initialValues.content);
+    if (initialValues.category !== undefined) setCategory(initialValues.category);
     if (initialValues.isAnonymous !== undefined) setAnonymous(initialValues.isAnonymous);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialValues?.title, initialValues?.content, initialValues?.isAnonymous]);
+  }, [initialValues?.title, initialValues?.content, initialValues?.category, initialValues?.isAnonymous]);
 
   useEffect(() => {
     if (!dropdownOpen) return;

--- a/src/components/manage/ReportManageSection.tsx
+++ b/src/components/manage/ReportManageSection.tsx
@@ -2,20 +2,43 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { Upload, CalendarIcon, Search } from "lucide-react";
 import { Calendar } from "@/components/ui/calendar";
 import ReportCard from "@/components/report/ReportCard";
 import Pagination from "@/components/shared/Pagination";
+import { useInfiniteScroll } from "@/hooks/common";
 import { reportApi, type ReportPreviewItem } from "@/api";
 
 const PAGE_SIZE = 9;
+/** 팀별 그룹핑 시 무한스크롤 한 페이지 크기 (초기 로딩 ~30개) */
+const GROUP_PAGE_SIZE = 30;
 
-/** 서버 필터용 날짜 포맷 (yyyy-MM-dd) */
 function toApiDate(d?: Date): string | undefined {
   return d ? format(d, "yyyy-MM-dd") : undefined;
+}
+
+/** 서버 필터 파라미터 (기간·검색어) */
+type ReportFilters = {
+  startDate?: string;
+  endDate?: string;
+  keyword?: string;
+};
+
+function renderReportCard(r: ReportPreviewItem) {
+  return (
+    <ReportCard
+      key={r.postId}
+      id={r.postId}
+      tag={r.groupName}
+      title={r.title}
+      author={r.authorName}
+      generation={r.generation}
+      date={r.date}
+    />
+  );
 }
 
 export default function ReportManageSection() {
@@ -43,52 +66,28 @@ export default function ReportManageSection() {
   const pageIndex = currentPage - 1;
   const resetPage = () => setCurrentPage(1);
 
-  // 검색 실행 (Enter 또는 아이콘 클릭) — 입력값 확정 + 1페이지로
   const runSearch = () => {
     setSubmittedKeyword(search.trim());
     setCurrentPage(1);
   };
 
-  const apiStart = toApiDate(startDate);
-  const apiEnd = toApiDate(endDate);
-  const keyword = submittedKeyword || undefined;
+  const filters: ReportFilters = {
+    startDate: toApiDate(startDate),
+    endDate: toApiDate(endDate),
+    keyword: submittedKeyword || undefined,
+  };
 
-  // 관리자는 role 기준으로 전체 보고서가 내려옴 / 기간·검색 모두 서버 필터
+  // 평면 모드: 페이지네이션
   const { data: res, isLoading, isError } = useQuery({
-    queryKey: ["reports", "manage", pageIndex, apiStart, apiEnd, keyword],
+    queryKey: ["reports", "manage", "flat", pageIndex, filters.startDate, filters.endDate, filters.keyword],
     queryFn: () =>
-      reportApi.getList({ page: pageIndex, size: PAGE_SIZE, startDate: apiStart, endDate: apiEnd, keyword }),
+      reportApi.getList({ page: pageIndex, size: PAGE_SIZE, ...filters }),
   });
 
   const reportPage = res?.data?.data?.reports;
-  const reports: ReportPreviewItem[] = reportPage?.content ?? [];
+  const flatReports: ReportPreviewItem[] = reportPage?.content ?? [];
   const totalPagesCount = Math.max(1, reportPage?.page?.totalPages ?? 1);
   const totalPages = Array.from({ length: totalPagesCount }, (_, i) => i + 1);
-
-  // TODO(백엔드): GET /report에 그룹(팀) 필터 파라미터(예: groupId)가 추가되면
-  // 아래 클라이언트 그룹핑을 제거하고 서버 필터+페이지네이션으로 전환할 것.
-  // 현재는 서버 필터 없이 "현재 페이지에 받아온 reports"만 groupName으로 묶어서 보여주므로,
-  // 한 팀의 보고서가 PAGE_SIZE(9)개를 넘으면 페이지 밖에 있는 나머지는 그룹핑 화면에 안 보임.
-  // "팀으로 그룹핑" 토글 시 groupName별로 묶기 (현재 페이지 기준)
-  const grouped = reports.reduce<Record<string, ReportPreviewItem[]>>(
-    (acc, r) => {
-      (acc[r.groupName] ??= []).push(r);
-      return acc;
-    },
-    {},
-  );
-
-  const renderCard = (r: ReportPreviewItem) => (
-    <ReportCard
-      key={r.postId}
-      id={r.postId}
-      tag={r.groupName}
-      title={r.title}
-      author={r.authorName}
-      generation={r.generation}
-      date={r.date}
-    />
-  );
 
   return (
     <div className="max-w-6xl mx-auto">
@@ -204,41 +203,107 @@ export default function ReportManageSection() {
         </div>
       </div>
 
-      {/* 상태 표시 */}
-      {isLoading && (
-        <div className="text-center py-16 text-gray-500">불러오는 중...</div>
-      )}
-      {isError && (
-        <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>
-      )}
-
-      {!isLoading && !isError && (
+      {/* 그룹핑 ON: 무한스크롤 팀별 묶음 (별도 컴포넌트로 마운트) */}
+      {groupByTeam ? (
+        <GroupedReportList filters={filters} />
+      ) : (
         <>
-          {reports.length === 0 ? (
-            <div className="py-16 text-center text-sm text-gray-400">보고서가 없습니다.</div>
-          ) : groupByTeam ? (
-            /* 팀(그룹)별 묶음 보기 */
-            <div className="space-y-8 mb-6">
-              {Object.entries(grouped).map(([groupName, items]) => (
-                <div key={groupName}>
-                  <h2 className="text-sm font-semibold text-gray-700 mb-3">{groupName}</h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                    {items.map(renderCard)}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            /* 평면 그리드 */
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 mb-6">
-              {reports.map(renderCard)}
-            </div>
+          {isLoading && (
+            <div className="text-center py-16 text-gray-500">불러오는 중...</div>
           )}
-
-          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+          {isError && (
+            <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>
+          )}
+          {!isLoading && !isError && (
+            <>
+              {flatReports.length === 0 ? (
+                <div className="py-16 text-center text-sm text-gray-400">보고서가 없습니다.</div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 mb-6">
+                  {flatReports.map(renderReportCard)}
+                </div>
+              )}
+              <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+            </>
+          )}
         </>
       )}
 
+    </div>
+  );
+}
+
+/**
+ * 팀(그룹)별 묶음 보기 — 무한스크롤.
+ * 초기 GROUP_PAGE_SIZE개를 받고, 스크롤 끝에 닿으면 다음 페이지를 이어 붙여 팀별로 묶어 표시.
+ * groupByTeam=true일 때만 마운트되므로 useInfiniteQuery가 항상 실제 queryFn으로 실행됨.
+ */
+function GroupedReportList({ filters }: { filters: ReportFilters }) {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = useInfiniteQuery({
+    queryKey: ["reports", "manage", "grouped", filters.startDate, filters.endDate, filters.keyword],
+    queryFn: ({ pageParam }) =>
+      reportApi.getList({ page: pageParam, size: GROUP_PAGE_SIZE, ...filters }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const page = lastPage?.data?.data?.reports?.page;
+      if (!page) return undefined;
+      return page.number < page.totalPages - 1 ? page.number + 1 : undefined;
+    },
+  });
+
+  const sentinelRef = useInfiniteScroll<HTMLDivElement>({
+    hasMore: hasNextPage,
+    isLoading: isFetchingNextPage,
+    onLoadMore: fetchNextPage,
+  });
+
+  // 누적된 전체 결과를 팀(groupName)별로 묶기
+  const allReports: ReportPreviewItem[] =
+    data?.pages.flatMap((p) => p?.data?.data?.reports?.content ?? []) ?? [];
+  const grouped = allReports.reduce<Record<string, ReportPreviewItem[]>>((acc, r) => {
+    (acc[r.groupName] ??= []).push(r);
+    return acc;
+  }, {});
+
+  if (isLoading) {
+    return <div className="text-center py-16 text-gray-500">불러오는 중...</div>;
+  }
+  if (isError) {
+    return <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>;
+  }
+  if (allReports.length === 0) {
+    return <div className="py-16 text-center text-sm text-gray-400">보고서가 없습니다.</div>;
+  }
+
+  return (
+    <div className="mb-6">
+      {Object.entries(grouped).map(([groupName, items], index, arr) => (
+        <div key={groupName}>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-700">{groupName}</h2>
+            <span className="text-xs text-gray-400">{items.length}건</span>
+          </div>
+          {/* 최대 9개(3줄) 높이로 고정 — 초과분은 박스 안에서 세로 스크롤 */}
+          <div className="max-h-[42rem] overflow-y-auto pr-1">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+              {items.map(renderReportCard)}
+            </div>
+          </div>
+          {index < arr.length - 1 && <hr className="my-8 border-gray-200" />}
+        </div>
+      ))}
+      {/* 무한스크롤 트리거 */}
+      <div ref={sentinelRef} className="h-4 mt-8" />
+      {isFetchingNextPage && (
+        <div className="text-center py-4 text-sm text-gray-400">불러오는 중...</div>
+      )}
     </div>
   );
 }

--- a/src/components/manage/ReportManageSection.tsx
+++ b/src/components/manage/ReportManageSection.tsx
@@ -65,6 +65,10 @@ export default function ReportManageSection() {
   const totalPagesCount = Math.max(1, reportPage?.page?.totalPages ?? 1);
   const totalPages = Array.from({ length: totalPagesCount }, (_, i) => i + 1);
 
+  // TODO(백엔드): GET /report에 그룹(팀) 필터 파라미터(예: groupId)가 추가되면
+  // 아래 클라이언트 그룹핑을 제거하고 서버 필터+페이지네이션으로 전환할 것.
+  // 현재는 서버 필터 없이 "현재 페이지에 받아온 reports"만 groupName으로 묶어서 보여주므로,
+  // 한 팀의 보고서가 PAGE_SIZE(9)개를 넘으면 페이지 밖에 있는 나머지는 그룹핑 화면에 안 보임.
   // "팀으로 그룹핑" 토글 시 groupName별로 묶기 (현재 페이지 기준)
   const grouped = reports.reduce<Record<string, ReportPreviewItem[]>>(
     (acc, r) => {

--- a/src/components/manage/ReportManageSection.tsx
+++ b/src/components/manage/ReportManageSection.tsx
@@ -52,8 +52,10 @@ export default function ReportManageSection() {
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (startRef.current && !startRef.current.contains(e.target as Node)) setCalendarOpenStart(false);
-      if (endRef.current && !endRef.current.contains(e.target as Node)) setCalendarOpenEnd(false);
+      if (startRef.current && !startRef.current.contains(e.target as Node))
+        setCalendarOpenStart(false);
+      if (endRef.current && !endRef.current.contains(e.target as Node))
+        setCalendarOpenEnd(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -78,8 +80,20 @@ export default function ReportManageSection() {
   };
 
   // 평면 모드: 페이지네이션
-  const { data: res, isLoading, isError } = useQuery({
-    queryKey: ["reports", "manage", "flat", pageIndex, filters.startDate, filters.endDate, filters.keyword],
+  const {
+    data: res,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: [
+      "reports",
+      "manage",
+      "flat",
+      pageIndex,
+      filters.startDate,
+      filters.endDate,
+      filters.keyword,
+    ],
     queryFn: () =>
       reportApi.getList({ page: pageIndex, size: PAGE_SIZE, ...filters }),
   });
@@ -91,7 +105,6 @@ export default function ReportManageSection() {
 
   return (
     <div className="max-w-6xl mx-auto">
-
       {/* 헤더: 제목 + 업로드 버튼 */}
       <div className="flex items-center justify-between mb-10">
         <h1 className="text-h1 text-gray-900">전체 보고서 관리</h1>
@@ -99,8 +112,7 @@ export default function ReportManageSection() {
           onClick={() => router.push("/report/write")}
           className="px-6 py-3 bg-gray-800 text-white rounded-2xl font-medium text-base hover:bg-[#3E434A]/90 transition-colors flex items-center gap-4 shrink-0 whitespace-nowrap tracking-wide"
         >
-          <Upload size={18} />
-          새 보고서 업로드
+          <Upload size={18} />새 보고서 업로드
         </button>
       </div>
 
@@ -112,20 +124,33 @@ export default function ReportManageSection() {
             <div ref={startRef} className="relative">
               <button
                 type="button"
-                onClick={() => { setCalendarOpenStart((v) => !v); setCalendarOpenEnd(false); }}
+                onClick={() => {
+                  setCalendarOpenStart((v) => !v);
+                  setCalendarOpenEnd(false);
+                }}
                 aria-haspopup="dialog"
                 aria-expanded={calendarOpenStart}
                 aria-label="시작일 선택"
                 className="w-40 border border-gray-200 rounded-lg px-3 py-1.5 text-sm flex items-center justify-between bg-white focus:outline-none focus:ring-2 focus:ring-report-ring"
               >
                 <span className={startDate ? "text-gray-700" : "text-gray-400"}>
-                  {startDate ? format(startDate, "yyyy.MM.dd", { locale: ko }) : "시작일"}
+                  {startDate
+                    ? format(startDate, "yyyy.MM.dd", { locale: ko })
+                    : "시작일"}
                 </span>
                 <CalendarIcon size={14} className="text-gray-400" />
               </button>
               {calendarOpenStart && (
                 <div className="absolute z-10 mt-1 bg-white border border-gray-200 rounded-lg shadow-md">
-                  <Calendar mode="single" selected={startDate} onSelect={(d) => { setStartDate(d); setCalendarOpenStart(false); resetPage(); }} />
+                  <Calendar
+                    mode="single"
+                    selected={startDate}
+                    onSelect={(d) => {
+                      setStartDate(d);
+                      setCalendarOpenStart(false);
+                      resetPage();
+                    }}
+                  />
                 </div>
               )}
             </div>
@@ -133,27 +158,44 @@ export default function ReportManageSection() {
             <div ref={endRef} className="relative">
               <button
                 type="button"
-                onClick={() => { setCalendarOpenEnd((v) => !v); setCalendarOpenStart(false); }}
+                onClick={() => {
+                  setCalendarOpenEnd((v) => !v);
+                  setCalendarOpenStart(false);
+                }}
                 aria-haspopup="dialog"
                 aria-expanded={calendarOpenEnd}
                 aria-label="종료일 선택"
                 className="w-40 border border-gray-200 rounded-lg px-3 py-1.5 text-sm flex items-center justify-between bg-white focus:outline-none focus:ring-2 focus:ring-report-ring"
               >
                 <span className={endDate ? "text-gray-700" : "text-gray-400"}>
-                  {endDate ? format(endDate, "yyyy.MM.dd", { locale: ko }) : "종료일"}
+                  {endDate
+                    ? format(endDate, "yyyy.MM.dd", { locale: ko })
+                    : "종료일"}
                 </span>
                 <CalendarIcon size={14} className="text-gray-400" />
               </button>
               {calendarOpenEnd && (
                 <div className="absolute z-10 mt-1 bg-white border border-gray-200 rounded-lg shadow-md">
-                  <Calendar mode="single" selected={endDate} onSelect={(d) => { setEndDate(d); setCalendarOpenEnd(false); resetPage(); }} />
+                  <Calendar
+                    mode="single"
+                    selected={endDate}
+                    onSelect={(d) => {
+                      setEndDate(d);
+                      setCalendarOpenEnd(false);
+                      resetPage();
+                    }}
+                  />
                 </div>
               )}
             </div>
             {(startDate || endDate) && (
               <button
                 type="button"
-                onClick={() => { setStartDate(undefined); setEndDate(undefined); resetPage(); }}
+                onClick={() => {
+                  setStartDate(undefined);
+                  setEndDate(undefined);
+                  resetPage();
+                }}
                 className="text-gray-400 hover:text-gray-600 transition-colors shrink-0"
               >
                 초기화
@@ -195,7 +237,9 @@ export default function ReportManageSection() {
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") runSearch(); }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") runSearch();
+            }}
             placeholder="제목, 작성자로 검색"
             aria-label="제목·작성자 검색"
             className="flex-1 text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
@@ -209,26 +253,35 @@ export default function ReportManageSection() {
       ) : (
         <>
           {isLoading && (
-            <div className="text-center py-16 text-gray-500">불러오는 중...</div>
+            <div className="text-center py-16 text-gray-500">
+              불러오는 중...
+            </div>
           )}
           {isError && (
-            <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>
+            <div className="text-center py-16 text-red-500">
+              보고서를 불러오지 못했습니다.
+            </div>
           )}
           {!isLoading && !isError && (
             <>
               {flatReports.length === 0 ? (
-                <div className="py-16 text-center text-sm text-gray-400">보고서가 없습니다.</div>
+                <div className="py-16 text-center text-body-sm text-gray-400">
+                  보고서가 없습니다.
+                </div>
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 mb-6">
                   {flatReports.map(renderReportCard)}
                 </div>
               )}
-              <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+              />
             </>
           )}
         </>
       )}
-
     </div>
   );
 }
@@ -247,7 +300,14 @@ function GroupedReportList({ filters }: { filters: ReportFilters }) {
     isLoading,
     isError,
   } = useInfiniteQuery({
-    queryKey: ["reports", "manage", "grouped", filters.startDate, filters.endDate, filters.keyword],
+    queryKey: [
+      "reports",
+      "manage",
+      "grouped",
+      filters.startDate,
+      filters.endDate,
+      filters.keyword,
+    ],
     queryFn: ({ pageParam }) =>
       reportApi.getList({ page: pageParam, size: GROUP_PAGE_SIZE, ...filters }),
     initialPageParam: 0,
@@ -267,19 +327,32 @@ function GroupedReportList({ filters }: { filters: ReportFilters }) {
   // 누적된 전체 결과를 팀(groupName)별로 묶기
   const allReports: ReportPreviewItem[] =
     data?.pages.flatMap((p) => p?.data?.data?.reports?.content ?? []) ?? [];
-  const grouped = allReports.reduce<Record<string, ReportPreviewItem[]>>((acc, r) => {
-    (acc[r.groupName] ??= []).push(r);
-    return acc;
-  }, {});
+  const grouped = allReports.reduce<Record<string, ReportPreviewItem[]>>(
+    (acc, r) => {
+      (acc[r.groupName] ??= []).push(r);
+      return acc;
+    },
+    {},
+  );
 
   if (isLoading) {
-    return <div className="text-center py-16 text-gray-500">불러오는 중...</div>;
+    return (
+      <div className="text-center py-16 text-gray-500">불러오는 중...</div>
+    );
   }
   if (isError) {
-    return <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>;
+    return (
+      <div className="text-center py-16 text-red-500">
+        보고서를 불러오지 못했습니다.
+      </div>
+    );
   }
   if (allReports.length === 0) {
-    return <div className="py-16 text-center text-sm text-gray-400">보고서가 없습니다.</div>;
+    return (
+      <div className="py-16 text-center text-body-sm text-gray-400">
+        보고서가 없습니다.
+      </div>
+    );
   }
 
   return (
@@ -287,10 +360,12 @@ function GroupedReportList({ filters }: { filters: ReportFilters }) {
       {Object.entries(grouped).map(([groupName, items], index, arr) => (
         <div key={groupName}>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold text-gray-700">{groupName}</h2>
-            <span className="text-xs text-gray-400">{items.length}건</span>
+            <h2 className="text-body-sm font-semibold text-gray-700">
+              {groupName}
+            </h2>
+            <span className="text-caption text-gray-400">{items.length}건</span>
           </div>
-          {/* 최대 9개(3줄) 높이로 고정 — 초과분은 박스 안에서 세로 스크롤 */}
+          {/* 고정 픽셀 UI(styling.md §5): 최대 9개(3줄)만 보이고 초과분은 박스 안에서 세로 스크롤 */}
           <div className="max-h-[42rem] overflow-y-auto pr-1">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
               {items.map(renderReportCard)}
@@ -302,7 +377,9 @@ function GroupedReportList({ filters }: { filters: ReportFilters }) {
       {/* 무한스크롤 트리거 */}
       <div ref={sentinelRef} className="h-4 mt-8" />
       {isFetchingNextPage && (
-        <div className="text-center py-4 text-sm text-gray-400">불러오는 중...</div>
+        <div className="text-center py-4 text-body-sm text-gray-400">
+          불러오는 중...
+        </div>
       )}
     </div>
   );

--- a/src/hooks/common/index.ts
+++ b/src/hooks/common/index.ts
@@ -1,3 +1,4 @@
 export { useDisclosure } from "./useDisclosure";
 export { useDebounce } from "./useDebounce";
 export { useClickOutside } from "./useClickOutside";
+export { useInfiniteScroll } from "./useInfiniteScroll";

--- a/src/hooks/common/useInfiniteScroll.ts
+++ b/src/hooks/common/useInfiniteScroll.ts
@@ -1,0 +1,56 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+type UseInfiniteScrollOptions = {
+  /** 더 불러올 페이지가 있는지 */
+  hasMore: boolean;
+  /** 현재 로딩 중인지 — 중복 호출 방지 */
+  isLoading: boolean;
+  /** 감지 요소가 뷰포트에 들어오면 호출 (다음 페이지 로드) */
+  onLoadMore: () => void;
+  /** 미리 로드 여백 (기본 200px 앞서 트리거) */
+  rootMargin?: string;
+};
+
+/**
+ * 무한스크롤 훅 — 반환한 ref를 리스트 끝 "sentinel" 요소에 달면,
+ * 그 요소가 뷰포트에 들어올 때 onLoadMore를 호출한다.
+ *
+ * 왜 쓰나: 목록을 페이지 단위로 이어 붙이는(무한스크롤) 로직을 컴포넌트 밖으로 분리해 재사용.
+ *
+ * @example
+ * const sentinelRef = useInfiniteScroll<HTMLDivElement>({
+ *   hasMore: hasNextPage,
+ *   isLoading: isFetchingNextPage,
+ *   onLoadMore: fetchNextPage,
+ * });
+ * <div ref={sentinelRef} />
+ */
+export function useInfiniteScroll<T extends HTMLElement = HTMLElement>({
+  hasMore,
+  isLoading,
+  onLoadMore,
+  rootMargin = "200px",
+}: UseInfiniteScrollOptions) {
+  const ref = useRef<T>(null);
+  // onLoadMore가 매 렌더 새로 만들어져도 effect가 재등록되지 않도록 ref로 고정
+  const onLoadMoreRef = useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !hasMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoading) {
+          onLoadMoreRef.current();
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, rootMargin]);
+
+  return ref;
+}

--- a/src/hooks/common/useInfiniteScroll.ts
+++ b/src/hooks/common/useInfiniteScroll.ts
@@ -33,9 +33,11 @@ export function useInfiniteScroll<T extends HTMLElement = HTMLElement>({
   rootMargin = "200px",
 }: UseInfiniteScrollOptions) {
   const ref = useRef<T>(null);
-  // onLoadMore가 매 렌더 새로 만들어져도 effect가 재등록되지 않도록 ref로 고정
+  // onLoadMore가 매 렌더 새로 만들어져도 observer를 재등록하지 않도록 ref로 고정
   const onLoadMoreRef = useRef(onLoadMore);
-  onLoadMoreRef.current = onLoadMore;
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
 
   useEffect(() => {
     const el = ref.current;

--- a/src/hooks/news/useNewsList.ts
+++ b/src/hooks/news/useNewsList.ts
@@ -4,15 +4,16 @@ import { useQuery } from "@tanstack/react-query";
 import { newsApi, type NewsCategory, type NewsListResponse } from "@/api";
 
 export type UseNewsListParams = {
-  category?: NewsCategory;
+  category?: NewsCategory | NewsCategory[];
   keyword?: string;
   page: number;
   size?: number;
 };
 
 export function useNewsList({ category, keyword, page, size = 11 }: UseNewsListParams) {
+  const categoryKey = Array.isArray(category) ? category.join(",") : category;
   return useQuery({
-    queryKey: ["news-list", category, keyword, page, size],
+    queryKey: ["news-list", categoryKey, keyword, page, size],
     queryFn: async (): Promise<NewsListResponse> => {
       const res = await newsApi.getList({
         category,


### PR DESCRIPTION
## Summary
- 글 수정(edit) 진입 시 제목/내용이 비어있던 버그 수정 — 기존 글 데이터를 조회해 폼에 채우도록 처리
- `category` 쿼리 파라미터 배열 지원 반영 (소식 "전체" 탭이 클라이언트 필터링 대신 서버 필터링으로 동작)
- `newsletterType`(주간/특집/공지) 필드 반영, 뉴스레터 탭 필터 연결
- 보고서 "팀으로 그룹핑" 페이지네이션 누락 한계를 TODO 주석으로 기록 (백엔드 `groupId` 필터 요청 중)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 뉴스 목록의 탭이 공지까지 확장되고, 글 유형에 맞는 라벨이 표시됩니다.
  * 뉴스/공지 목록에서 여러 카테고리 조건으로 조회할 수 있습니다.
  * 리포트 관리에서 팀별 그룹 보기로 전환 시 무한 스크롤 형태로 확인할 수 있습니다.
* **Bug Fixes**
  * 뉴스/공지 수정 화면에서 카테고리와 기본 입력값이 더 정확하게 불러와지도록 개선되었습니다.
  * 탭 선택에 따른 목록 필터링이 더 일관되게 동작하도록 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->