### PR TITLE
feat: 개별 HWP 다운로드 파일명 규칙 적용 ([팀명]_작성자_yyMMdd.hwp)

### DIFF
--- a/src/app/report/[id]/page.tsx
+++ b/src/app/report/[id]/page.tsx
@@ -28,7 +28,15 @@ function buildHwpFilename(detail?: ReportDetail): string {
   const team = detail.reportInfoDTO.groupInfoDTO.groupName;
   const author = detail.postInfoDTO.authorName;
   const date = detail.reportInfoDTO.date;
-  const dateStr = date ? format(new Date(date), "yyMMdd") : "";
+  // formatDate와 동일하게 파싱 실패를 삼켜 예외를 던지지 않음 (handleExport의 objectURL 누수 방지)
+  let dateStr = "";
+  if (date) {
+    try {
+      dateStr = format(new Date(date), "yyMMdd");
+    } catch {
+      dateStr = "";
+    }
+  }
   const parts = [team, author, dateStr].filter(Boolean).map(sanitizeFilePart);
   const base = parts.join("_") || "report";
   return `${base}.hwp`;

--- a/src/app/report/[id]/page.tsx
+++ b/src/app/report/[id]/page.tsx
@@ -17,6 +17,23 @@ function formatDate(iso?: string): string {
   }
 }
 
+/** 파일명에 못 쓰는 문자(\ / : * ? " < > |)와 공백을 _로 치환 */
+function sanitizeFilePart(v: string): string {
+  return v.replace(/[\\/:*?"<>|\s]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+/** 개별 HWP 다운로드 파일명 규칙: [팀명]_작성자_날짜(yyMMdd).hwp */
+function buildHwpFilename(detail?: ReportDetail): string {
+  if (!detail) return "report.hwp";
+  const team = detail.reportInfoDTO.groupInfoDTO.groupName;
+  const author = detail.postInfoDTO.authorName;
+  const date = detail.reportInfoDTO.date;
+  const dateStr = date ? format(new Date(date), "yyMMdd") : "";
+  const parts = [team, author, dateStr].filter(Boolean).map(sanitizeFilePart);
+  const base = parts.join("_") || "report";
+  return `${base}.hwp`;
+}
+
 export default function ReportDetailPage() {
   const router = useRouter();
   const params = useParams();
@@ -24,7 +41,11 @@ export default function ReportDetailPage() {
   const invalidId = !Number.isFinite(postId); // /report/abc 같은 잘못된 경로
   useMe(); // userId·role 하이드레이트 (수정 버튼 작성자 검증·HWP 권한용)
 
-  const { data: res, isLoading, isError } = useQuery({
+  const {
+    data: res,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ["report", postId],
     queryFn: () => reportApi.getById(postId),
     enabled: !invalidId,
@@ -44,7 +65,8 @@ export default function ReportDetailPage() {
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+      if (menuRef.current && !menuRef.current.contains(e.target as Node))
+        setMenuOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -56,7 +78,7 @@ export default function ReportDetailPage() {
       const url = URL.createObjectURL(fileRes.data as Blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `${detail?.postInfoDTO.title ?? "report"}.hwp`;
+      a.download = buildHwpFilename(detail);
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -68,7 +90,8 @@ export default function ReportDetailPage() {
 
   const handleDelete = async () => {
     setMenuOpen(false);
-    if (!window.confirm("이 보고서를 삭제할까요? 삭제 후 되돌릴 수 없습니다.")) return;
+    if (!window.confirm("이 보고서를 삭제할까요? 삭제 후 되돌릴 수 없습니다."))
+      return;
     try {
       setDeleting(true);
       await reportApi.remove(postId);
@@ -83,7 +106,6 @@ export default function ReportDetailPage() {
   return (
     <main className="min-h-screen bg-white">
       <div className="max-w-4xl mx-auto px-6 py-10">
-
         {/* 목록으로 + ⋮(수정/삭제) */}
         <div className="flex items-center justify-between mb-6">
           <button
@@ -113,7 +135,10 @@ export default function ReportDetailPage() {
                   <button
                     type="button"
                     role="menuitem"
-                    onClick={() => { setMenuOpen(false); router.push(`/report/write?edit=${postId}`); }}
+                    onClick={() => {
+                      setMenuOpen(false);
+                      router.push(`/report/write?edit=${postId}`);
+                    }}
                     className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                   >
                     <Pencil size={14} /> 수정
@@ -133,13 +158,17 @@ export default function ReportDetailPage() {
         </div>
 
         {invalidId && (
-          <div className="text-center py-16 text-gray-500">잘못된 보고서 주소입니다.</div>
+          <div className="text-center py-16 text-gray-500">
+            잘못된 보고서 주소입니다.
+          </div>
         )}
         {!invalidId && isLoading && (
           <div className="text-center py-16 text-gray-500">불러오는 중...</div>
         )}
         {!invalidId && isError && (
-          <div className="text-center py-16 text-red-500">보고서를 불러오지 못했습니다.</div>
+          <div className="text-center py-16 text-red-500">
+            보고서를 불러오지 못했습니다.
+          </div>
         )}
 
         {!invalidId && !isLoading && !isError && detail && (
@@ -166,7 +195,10 @@ function ReportDetailView({
     queryFn: () => groupApi.getById(report.groupInfoDTO.groupId),
   });
   const genByUserId = new Map<number, number>(
-    (groupRes?.data?.data?.members ?? []).map((m) => [m.userId, m.userGeneration]),
+    (groupRes?.data?.data?.members ?? []).map((m) => [
+      m.userId,
+      m.userGeneration,
+    ]),
   );
 
   const meta = [
@@ -224,7 +256,9 @@ function ReportDetailView({
       <div className="divide-y divide-gray-200">
         {/* 1. 활동 내용 */}
         <section className="py-8 first:pt-0">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">1. 활동 내용</h3>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">
+            1. 활동 내용
+          </h3>
           <p className="text-sm leading-6 text-gray-700 whitespace-pre-wrap mb-4">
             {post.content || "내용이 없습니다."}
           </p>
@@ -240,7 +274,9 @@ function ReportDetailView({
 
         {/* 2. 참여자 명단 */}
         <section className="py-8">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">2. 참여자 명단</h3>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">
+            2. 참여자 명단
+          </h3>
           {report.reportMembers.length === 0 ? (
             <p className="text-sm text-gray-400">참여자 정보가 없습니다.</p>
           ) : (
@@ -262,7 +298,9 @@ function ReportDetailView({
 
         {/* 3. 소감 */}
         <section className="py-8">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">3. 스터디 후 느낀 점</h3>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">
+            3. 스터디 후 느낀 점
+          </h3>
           <p className="text-sm leading-6 text-gray-700 whitespace-pre-wrap">
             {report.reflection || "내용이 없습니다."}
           </p>
@@ -270,7 +308,9 @@ function ReportDetailView({
 
         {/* 4. 다음 주 계획 */}
         <section className="py-8">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">4. 다음 주 계획</h3>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">
+            4. 다음 주 계획
+          </h3>
           <p className="text-sm leading-6 text-gray-700 whitespace-pre-wrap">
             {report.nextPlan || "내용이 없습니다."}
           </p>


### PR DESCRIPTION
- 기존 {제목}.hwp → {팀명}_{작성자}_{날짜(yyMMdd)}.hwp
- 파일명 금지 문자·공백은 _로 치환

## 🔗 관련 이슈                                                                                                                                
Closes #112 

## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✨ 추가/수정 내용


## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HWP 다운로드 파일명이 팀명, 작성자, 날짜를 반영한 형식으로 생성되며, 특수문자와 공백이 정리되어 더 일관되게 저장됩니다.

* **UI 개선**
  * 보고서 상세 화면의 안내 문구와 섹션 제목 표시가 정리되어 더 읽기 쉬워졌습니다.
  * 상단 메뉴의 수정/삭제 동작 흐름이 개선되어 화면 전환과 확인 절차가 더 자연스러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->