### PR TITLE
feat: 모임(gatherings) API 연결 + 참석 투표/명단

### DIFF
--- a/src/api/gathering.api.ts
+++ b/src/api/gathering.api.ts
@@ -87,8 +87,8 @@ export type AdminAttendanceList = {
   attendingMembers: AdminGatheringMember[];
   notAttendingMembers: AdminGatheringMember[];
   undecidedMembers: AdminGatheringMember[];
-  /** allMembersTarget=true 모임에서만 존재 */
-  unansweredMembers: AdminGatheringMember[];
+  /** allMembersTarget=true 모임에서만 존재 (아니면 서버가 생략) */
+  unansweredMembers?: AdminGatheringMember[];
 };
 
 export type CreateGatheringBody = {

--- a/src/api/gathering.api.ts
+++ b/src/api/gathering.api.ts
@@ -1,0 +1,129 @@
+/**
+ * 모임 일정(gatherings) API — 회식·MT·박람회 등 모임 + 참석 투표.
+ * @see /api/v1/gatherings/*
+ */
+import { api } from "./client";
+import { type ApiEnvelope } from "./auth.api";
+
+/** 모임 종류 */
+export type GatheringType = "DINING" | "MT" | "FAIR" | "EVENT" | "OTHER";
+/** 내 참석 상태 */
+export type MyAttendanceStatus =
+  "ATTENDING" | "NOT_ATTENDING" | "UNDECIDED" | "NOT_RESPONDED";
+/** 투표 값 (서버는 참석/불참 2지선다만 받음) */
+export type VoteDecision = "PASS" | "FAIL";
+
+/** 종류 enum ↔ 한글 라벨 */
+export const GATHERING_TYPE_LABEL: Record<GatheringType, string> = {
+  DINING: "회식",
+  MT: "MT",
+  FAIR: "박람회",
+  EVENT: "행사",
+  OTHER: "기타",
+};
+
+export type AttendanceSummary = {
+  attending: number;
+  notAttending: number;
+  undecided: number;
+  unanswered: number;
+  total: number;
+};
+
+/** 모임 목록/상세 응답 */
+export type Gathering = {
+  id: number;
+  title: string;
+  type: GatheringType;
+  description: string;
+  gatheringDate: string;
+  location: string;
+  voteDeadline: string;
+  voteClosed: boolean;
+  allMembersTarget: boolean;
+  authorGeneration: number;
+  authorName: string;
+  summary: AttendanceSummary;
+  myStatus: MyAttendanceStatus;
+  createdAt: string;
+  viewCount: number;
+};
+
+export type GatheringMember = {
+  memberId: number;
+  name: string;
+  generation: number;
+};
+
+/** 참석 명단 (일반) */
+export type AttendanceList = {
+  gatheringId: number;
+  title: string;
+  gatheringDate: string;
+  voteDeadline: string;
+  voteClosed: boolean;
+  summary: AttendanceSummary;
+  attendingMembers: GatheringMember[];
+  notAttendingMembers: GatheringMember[];
+  undecidedMembers: GatheringMember[];
+};
+
+/** 참석 명단 (관리자 — 미응답 포함) */
+export type AdminAttendanceList = AttendanceList & {
+  unansweredMembers: GatheringMember[];
+};
+
+export type CreateGatheringBody = {
+  title: string;
+  type: GatheringType;
+  description?: string;
+  gatheringDate: string;
+  location?: string;
+  voteDeadline: string;
+  allMembersTarget?: boolean;
+};
+
+export type UpdateGatheringBody = Partial<
+  Omit<CreateGatheringBody, "allMembersTarget">
+>;
+
+export const gatheringApi = {
+  /** 모임 목록 */
+  getList: () => api.get<ApiEnvelope<Gathering[]>>("/gatherings"),
+
+  /** 모임 상세 */
+  getById: (id: number) => api.get<ApiEnvelope<Gathering>>(`/gatherings/${id}`),
+
+  /** 모임 등록 */
+  create: (body: CreateGatheringBody) =>
+    api.post<ApiEnvelope<Gathering>>("/gatherings", body),
+
+  /** 모임 수정 */
+  update: (id: number, body: UpdateGatheringBody) =>
+    api.patch<ApiEnvelope<Gathering>>(`/gatherings/${id}`, body),
+
+  /** 모임 삭제 */
+  remove: (id: number) => api.delete<ApiEnvelope<null>>(`/gatherings/${id}`),
+
+  /** 참석 투표 (PASS=참석 / FAIL=불참) */
+  vote: (id: number, decision: VoteDecision, reason = "") =>
+    api.post<ApiEnvelope<null>>(`/gatherings/${id}/vote`, { decision, reason }),
+
+  /** 투표 마감 */
+  close: (id: number) =>
+    api.patch<ApiEnvelope<null>>(`/gatherings/${id}/close`),
+
+  /** 참석 명단 (일반) */
+  getAttendance: (id: number) =>
+    api.get<ApiEnvelope<AttendanceList>>(`/gatherings/${id}/attendance`),
+
+  /** 참석 명단 (관리자) */
+  getAdminAttendance: (id: number) =>
+    api.get<ApiEnvelope<AdminAttendanceList>>(
+      `/gatherings/${id}/attendance/admin`,
+    ),
+
+  /** 참석 명단 엑셀 (관리자, blob) */
+  exportAttendance: (id: number) =>
+    api.get(`/gatherings/${id}/attendance/export`, { responseType: "blob" }),
+};

--- a/src/api/gathering.api.ts
+++ b/src/api/gathering.api.ts
@@ -55,6 +55,14 @@ export type GatheringMember = {
   generation: number;
 };
 
+/** 관리자 명단 멤버 — 학번·학과·학년·투표일시 포함 (votedAt: 미응답자는 null) */
+export type AdminGatheringMember = GatheringMember & {
+  studentNumber: number;
+  major: string;
+  grade: string;
+  votedAt: string | null;
+};
+
 /** 참석 명단 (일반) */
 export type AttendanceList = {
   gatheringId: number;
@@ -68,9 +76,19 @@ export type AttendanceList = {
   undecidedMembers: GatheringMember[];
 };
 
-/** 참석 명단 (관리자 — 미응답 포함) */
-export type AdminAttendanceList = AttendanceList & {
-  unansweredMembers: GatheringMember[];
+/** 참석 명단 (관리자 — 학번·학과·학년·투표일시 + 미응답 포함). ADMIN 전용 */
+export type AdminAttendanceList = {
+  gatheringId: number;
+  title: string;
+  gatheringDate: string;
+  voteDeadline: string;
+  voteClosed: boolean;
+  summary: AttendanceSummary;
+  attendingMembers: AdminGatheringMember[];
+  notAttendingMembers: AdminGatheringMember[];
+  undecidedMembers: AdminGatheringMember[];
+  /** allMembersTarget=true 모임에서만 존재 */
+  unansweredMembers: AdminGatheringMember[];
 };
 
 export type CreateGatheringBody = {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -108,6 +108,7 @@ export {
   type AttendanceSummary,
   type Gathering,
   type GatheringMember,
+  type AdminGatheringMember,
   type AttendanceList,
   type AdminAttendanceList,
   type CreateGatheringBody,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -98,6 +98,22 @@ export {
   type ApplicantStatus,
 } from "./applicant.api";
 
+// Gathering (모임 일정)
+export {
+  gatheringApi,
+  GATHERING_TYPE_LABEL,
+  type GatheringType,
+  type MyAttendanceStatus,
+  type VoteDecision,
+  type AttendanceSummary,
+  type Gathering,
+  type GatheringMember,
+  type AttendanceList,
+  type AdminAttendanceList,
+  type CreateGatheringBody,
+  type UpdateGatheringBody,
+} from "./gathering.api";
+
 // Image
 export { imageApi } from "./image.api";
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,9 @@
   --color-success: #45cd89;
   --color-danger: #fc5e6e;
   --color-waiting: #3bc1e0; /* 참석 대기(Waiting) 청록 */
+  /* 모임 참석 투표 CTA 그라데이션 (마스코트 그린→민트) */
+  --color-mascot-from: #48c281;
+  --color-mascot-to: #58d4c5;
   /* 보고서 디자인 토큰 */
   --color-report-ring: #43d48b; /* 달력·입력 박스 포커스 외곽선 */
   --color-report-badge: #7bc747; /* 보고서 카드 뱃지 */
@@ -71,7 +74,14 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card); /* 36px */ --radius-sm: calc(var(--radius) - 4px); --radius-md: calc(var(--radius) - 2px); --radius-lg: var(--radius); --radius-xl: calc(var(--radius) + 4px); --radius-2xl: calc(var(--radius) + 8px); --radius-3xl: calc(var(--radius) + 12px); --radius-4xl: calc(var(--radius) + 16px);
+  --color-card: var(--card); /* 36px */
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
 }
 
 html,
@@ -80,7 +90,22 @@ body {
 }
 
 body {
-  font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  font-family:
+    "Pretendard Variable",
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    "Helvetica Neue",
+    "Segoe UI",
+    "Apple SD Gothic Neo",
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol",
+    sans-serif;
 }
 
 @keyframes cbu-marquee {
@@ -94,13 +119,13 @@ body {
 
 :root {
   /* ========== 반응형 타이포 토큰 (clamp: 360 ~ 1440px 사이에서 스케일) ========== */
-  --text-display: clamp(1.75rem, 1.25rem + 2.2vw, 2.5rem);   /* 28 → 40 */
-  --text-h1:      clamp(1.5rem, 1.1rem + 1.75vw, 2rem);      /* 24 → 32 */
-  --text-h2:      clamp(1.25rem, 1rem + 1.1vw, 1.5rem);      /* 20 → 24 */
-  --text-h3:      clamp(1.125rem, 1rem + 0.55vw, 1.25rem);   /* 18 → 20 */
-  --text-body:    clamp(0.9375rem, 0.875rem + 0.3vw, 1rem);  /* 15 → 16 */
+  --text-display: clamp(1.75rem, 1.25rem + 2.2vw, 2.5rem); /* 28 → 40 */
+  --text-h1: clamp(1.5rem, 1.1rem + 1.75vw, 2rem); /* 24 → 32 */
+  --text-h2: clamp(1.25rem, 1rem + 1.1vw, 1.5rem); /* 20 → 24 */
+  --text-h3: clamp(1.125rem, 1rem + 0.55vw, 1.25rem); /* 18 → 20 */
+  --text-body: clamp(0.9375rem, 0.875rem + 0.3vw, 1rem); /* 15 → 16 */
   --text-body-sm: clamp(0.8125rem, 0.78rem + 0.15vw, 0.875rem); /* 13 → 14 */
-  --text-xs:      0.75rem;                                   /* 12 고정 */
+  --text-xs: 0.75rem; /* 12 고정 */
 
   /* line-height */
   --leading-tight: 1.2;
@@ -109,12 +134,12 @@ body {
   --leading-relaxed: 1.65;
 
   /* ========== 스페이싱/레이아웃 토큰 ========== */
-  --container-px:    clamp(1.5rem, 0.4rem + 2.5vw, 9.375rem); /* 24 → 150 (기본) */
-  --container-px-lg: clamp(1rem, 15vw, 20rem);                /* 15% (최소 16, 최대 320) */
-  --section-gap:    clamp(2rem, 1.2rem + 3.5vw, 4rem);       /* 32 → 64 */
-  --block-gap:      clamp(1rem, 0.8rem + 0.8vw, 1.5rem);     /* 16 → 24 */
-  --card-radius:    clamp(0.75rem, 0.65rem + 0.4vw, 1rem);   /* 12 → 16 */
-  --touch-min:      2.75rem;                                  /* 44px */
+  --container-px: clamp(1.5rem, 0.4rem + 2.5vw, 9.375rem); /* 24 → 150 (기본) */
+  --container-px-lg: clamp(1rem, 15vw, 20rem); /* 15% (최소 16, 최대 320) */
+  --section-gap: clamp(2rem, 1.2rem + 3.5vw, 4rem); /* 32 → 64 */
+  --block-gap: clamp(1rem, 0.8rem + 0.8vw, 1.5rem); /* 16 → 24 */
+  --card-radius: clamp(0.75rem, 0.65rem + 0.4vw, 1rem); /* 12 → 16 */
+  --touch-min: 2.75rem; /* 44px */
 
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -235,16 +260,53 @@ body {
 /* ========== Figma 타이포 스케일 (고정 px · 디자인 스펙 1:1) ==========
    Figma "Text styles" 패널 기준. 표기 = 폰트크기/줄높이(%). 반응형이 필요 없는
    버튼·라벨·카드 등 디자인이 px로 못박은 곳에 사용(섹션 제목 등 반응형은 위 시맨틱 유틸). */
-@utility text-display-md  { font-size: 45px; line-height: 1.6; font-weight: 500; } /* Display/Medium */
-@utility text-headline-lg { font-size: 32px; line-height: 1.6; font-weight: 700; } /* Headline/Large */
-@utility text-headline-md { font-size: 28px; line-height: 1.6; font-weight: 700; } /* Headline/Medium */
-@utility text-headline-sm { font-size: 24px; line-height: 1.6; font-weight: 600; } /* Headline/small */
-@utility text-title-lg    { font-size: 20px; line-height: 1.6; font-weight: 600; } /* Title/Large */
-@utility text-title-md    { font-size: 16px; line-height: 1.6; font-weight: 600; } /* Title/Medium */
-@utility text-title-sm    { font-size: 14px; line-height: 1.6; font-weight: 600; } /* Title/small */
-@utility text-body-md     { font-size: 16px; line-height: 26px; }                  /* body/body 16·26 */
-@utility text-body-rg     { font-size: 14px; line-height: 21px; }                  /* body/small 14·21 */
-@utility text-body-loose  { font-size: 14px; line-height: 1.6; }                   /* body/small2 14 */
+@utility text-display-md {
+  font-size: 45px;
+  line-height: 1.6;
+  font-weight: 500;
+} /* Display/Medium */
+@utility text-headline-lg {
+  font-size: 32px;
+  line-height: 1.6;
+  font-weight: 700;
+} /* Headline/Large */
+@utility text-headline-md {
+  font-size: 28px;
+  line-height: 1.6;
+  font-weight: 700;
+} /* Headline/Medium */
+@utility text-headline-sm {
+  font-size: 24px;
+  line-height: 1.6;
+  font-weight: 600;
+} /* Headline/small */
+@utility text-title-lg {
+  font-size: 20px;
+  line-height: 1.6;
+  font-weight: 600;
+} /* Title/Large */
+@utility text-title-md {
+  font-size: 16px;
+  line-height: 1.6;
+  font-weight: 600;
+} /* Title/Medium */
+@utility text-title-sm {
+  font-size: 14px;
+  line-height: 1.6;
+  font-weight: 600;
+} /* Title/small */
+@utility text-body-md {
+  font-size: 16px;
+  line-height: 26px;
+} /* body/body 16·26 */
+@utility text-body-rg {
+  font-size: 14px;
+  line-height: 21px;
+} /* body/small 14·21 */
+@utility text-body-loose {
+  font-size: 14px;
+  line-height: 1.6;
+} /* body/small2 14 */
 
 /* ========== 레이아웃 유틸 ========== */
 @utility container-x {

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -9,7 +9,6 @@ import RequireMember from "@/components/auth/RequireMember";
 import KebabMenu from "@/components/common/KebabMenu";
 import Mascot, { type MascotEmotion } from "@/components/common/Mascot";
 import { StatusBadge } from "@/components/common/StatusBadge";
-import { useUserStore } from "@/store/userStore";
 import {
   useGathering,
   useAttendance,
@@ -66,8 +65,8 @@ export default function MeetingDetailPage() {
   const router = useRouter();
   const params = useParams();
   const id = Number(params?.id);
-  const canManage = useCanManageGathering(); // 수정/삭제/마감
-  const isAdmin = useUserStore((s) => s.isAdmin); // 참석명단 엑셀은 ADMIN 전용
+  const canManage = useCanManageGathering(); // 수정/삭제/마감 + 참석명단 엑셀
+  // ⚠️ 엑셀·관리자명단은 BE가 현재 ADMIN만 허용 → 운영진 확대는 BE 요청 필요
 
   const { data: meeting, isLoading, isError } = useGathering(id || null);
   const { data: attendance } = useAttendance(id || null);
@@ -222,7 +221,7 @@ export default function MeetingDetailPage() {
                 <Clock size={16} /> 응답 마감 {fmt(meeting.voteDeadline)}
               </span>
               <div className="flex items-center gap-2">
-                {isAdmin && (
+                {canManage && (
                   <button
                     type="button"
                     onClick={handleExport}

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -34,7 +34,7 @@ function fmt(iso?: string, pattern = "yyyy.MM.dd (EEE) HH:mm") {
   }
 }
 
-// 참석 투표 — 서버는 PASS/FAIL 2지선다. (UNDECIDED/미정 투표는 서버 미지원)
+// 참석 투표 (참석 / 불참)
 const VOTE_OPTIONS: {
   key: VoteDecision;
   label: string;
@@ -291,7 +291,7 @@ export default function MeetingDetailPage() {
                 </>
               )}
 
-              {/* 응답 명단 — 참석/불참 (미정 상태는 제거 결정) */}
+              {/* 응답 명단 */}
               {attendance && (
                 <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
                   {[

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -114,7 +114,10 @@ export default function MeetingDetailPage() {
 
   const handleDelete = () => {
     if (!window.confirm("이 모임을 삭제할까요?")) return;
-    deleteMutation.mutate(id, { onSuccess: () => router.push("/meeting") });
+    deleteMutation.mutate(id, {
+      onSuccess: () => router.push("/meeting"),
+      onError: () => alert("삭제 중 오류가 발생했습니다. 다시 시도해주세요."),
+    });
   };
 
   const handleClose = () => {
@@ -122,12 +125,17 @@ export default function MeetingDetailPage() {
       !window.confirm("투표를 마감할까요? 마감 후에는 응답을 받을 수 없어요.")
     )
       return;
-    closeMutation.mutate();
+    closeMutation.mutate(undefined, {
+      onError: () => alert("마감 중 오류가 발생했습니다. 다시 시도해주세요."),
+    });
   };
 
   const handleVote = () => {
     if (!choice) return;
-    voteMutation.mutate(choice);
+    voteMutation.mutate(choice, {
+      onError: () =>
+        alert("투표 저장 중 오류가 발생했습니다. 다시 시도해주세요."),
+    });
   };
 
   // 참석 명단 엑셀 다운로드 (ADMIN 전용)
@@ -267,7 +275,7 @@ export default function MeetingDetailPage() {
                           onClick={() => setChoiceOverride(opt.key)}
                           className={`flex flex-col items-center gap-3 rounded-2xl border-2 py-8 transition-colors ${
                             selected
-                              ? "border-success bg-[#def7eb]"
+                              ? "border-success bg-success/10"
                               : "border-gray-200 bg-white hover:border-gray-300"
                           }`}
                         >
@@ -283,7 +291,7 @@ export default function MeetingDetailPage() {
                     type="button"
                     disabled={!choice || voteMutation.isPending}
                     onClick={handleVote}
-                    className="mt-4 w-full rounded-full bg-gradient-to-b from-[#48c281] to-[#58d4c5] py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                    className="mt-4 w-full rounded-full bg-success py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     {voteMutation.isPending ? "제출 중..." : "제출하기"}
                   </button>

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -10,6 +10,7 @@ import KebabMenu from "@/components/common/KebabMenu";
 import Mascot, { type MascotEmotion } from "@/components/common/Mascot";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { useIsStaff } from "@/hooks/auth/useIsStaff";
+import { useUserStore } from "@/store/userStore";
 import {
   useGathering,
   useAttendance,
@@ -18,6 +19,7 @@ import {
   useCloseGathering,
 } from "@/hooks/meeting";
 import {
+  gatheringApi,
   GATHERING_TYPE_LABEL,
   type GatheringMember,
   type VoteDecision,
@@ -65,6 +67,7 @@ export default function MeetingDetailPage() {
   const params = useParams();
   const id = Number(params?.id);
   const isStaff = useIsStaff();
+  const isAdmin = useUserStore((s) => s.isAdmin); // 참석명단 엑셀은 ADMIN 전용
 
   const { data: meeting, isLoading, isError } = useGathering(id || null);
   const { data: attendance } = useAttendance(id || null);
@@ -126,6 +129,21 @@ export default function MeetingDetailPage() {
   const handleVote = () => {
     if (!choice) return;
     voteMutation.mutate(choice);
+  };
+
+  // 참석 명단 엑셀 다운로드 (ADMIN 전용)
+  const handleExport = async () => {
+    try {
+      const res = await gatheringApi.exportAttendance(id);
+      const url = URL.createObjectURL(res.data as Blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${meeting.title}_참석명단.xlsx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      alert("명단 다운로드에 실패했습니다.");
+    }
   };
 
   return (
@@ -203,16 +221,27 @@ export default function MeetingDetailPage() {
               <span className="flex items-center gap-1">
                 <Clock size={16} /> 응답 마감 {fmt(meeting.voteDeadline)}
               </span>
-              {isStaff && !meeting.voteClosed && (
-                <button
-                  type="button"
-                  onClick={handleClose}
-                  disabled={closeMutation.isPending}
-                  className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-40"
-                >
-                  {closeMutation.isPending ? "마감 중..." : "투표 마감"}
-                </button>
-              )}
+              <div className="flex items-center gap-2">
+                {isAdmin && (
+                  <button
+                    type="button"
+                    onClick={handleExport}
+                    className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition-colors hover:bg-gray-50"
+                  >
+                    명단 엑셀
+                  </button>
+                )}
+                {isStaff && !meeting.voteClosed && (
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={closeMutation.isPending}
+                    className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-40"
+                  >
+                    {closeMutation.isPending ? "마감 중..." : "투표 마감"}
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* 참석 투표 */}

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -291,9 +291,9 @@ export default function MeetingDetailPage() {
                 </>
               )}
 
-              {/* 응답 명단 */}
+              {/* 응답 명단 — 참석/불참 (미정 상태는 제거 결정) */}
               {attendance && (
-                <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
                   {[
                     {
                       ko: "참석 가능",
@@ -306,12 +306,6 @@ export default function MeetingDetailPage() {
                       en: "Negative",
                       tone: "text-danger",
                       list: attendance.notAttendingMembers,
-                    },
-                    {
-                      ko: "미정",
-                      en: "Waiting",
-                      tone: "text-waiting",
-                      list: attendance.undecidedMembers,
                     },
                   ].map((g) => (
                     <div

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -9,7 +9,6 @@ import RequireMember from "@/components/auth/RequireMember";
 import KebabMenu from "@/components/common/KebabMenu";
 import Mascot, { type MascotEmotion } from "@/components/common/Mascot";
 import { StatusBadge } from "@/components/common/StatusBadge";
-import { useIsStaff } from "@/hooks/auth/useIsStaff";
 import { useUserStore } from "@/store/userStore";
 import {
   useGathering,
@@ -17,6 +16,7 @@ import {
   useVoteGathering,
   useDeleteGathering,
   useCloseGathering,
+  useCanManageGathering,
 } from "@/hooks/meeting";
 import {
   gatheringApi,
@@ -66,7 +66,7 @@ export default function MeetingDetailPage() {
   const router = useRouter();
   const params = useParams();
   const id = Number(params?.id);
-  const isStaff = useIsStaff();
+  const canManage = useCanManageGathering(); // 수정/삭제/마감
   const isAdmin = useUserStore((s) => s.isAdmin); // 참석명단 엑셀은 ADMIN 전용
 
   const { data: meeting, isLoading, isError } = useGathering(id || null);
@@ -159,7 +159,7 @@ export default function MeetingDetailPage() {
               >
                 <ChevronLeft size={16} /> 목록으로
               </button>
-              {isStaff && (
+              {canManage && (
                 <KebabMenu
                   onEdit={() => router.push(`/meeting/write?id=${id}`)}
                   onDelete={handleDelete}
@@ -231,7 +231,7 @@ export default function MeetingDetailPage() {
                     명단 엑셀
                   </button>
                 )}
-                {isStaff && !meeting.voteClosed && (
+                {canManage && !meeting.voteClosed && (
                   <button
                     type="button"
                     onClick={handleClose}

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -291,7 +291,7 @@ export default function MeetingDetailPage() {
                     type="button"
                     disabled={!choice || voteMutation.isPending}
                     onClick={handleVote}
-                    className="mt-4 w-full rounded-full bg-success py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                    className="mt-4 w-full rounded-full bg-gradient-to-b from-mascot-from to-mascot-to py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     {voteMutation.isPending ? "제출 중..." : "제출하기"}
                   </button>

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -1,140 +1,139 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import { useState } from "react";
 import { ChevronLeft, Clock, Eye, MapPin } from "lucide-react";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 import RequireMember from "@/components/auth/RequireMember";
-import { useUserStore } from "@/store/userStore";
 import KebabMenu from "@/components/common/KebabMenu";
 import Mascot, { type MascotEmotion } from "@/components/common/Mascot";
 import { StatusBadge } from "@/components/common/StatusBadge";
+import { useIsStaff } from "@/hooks/auth/useIsStaff";
+import {
+  useGathering,
+  useAttendance,
+  useVoteGathering,
+  useDeleteGathering,
+  useCloseGathering,
+} from "@/hooks/meeting";
+import {
+  GATHERING_TYPE_LABEL,
+  type GatheringMember,
+  type VoteDecision,
+} from "@/api";
 
-// TODO: API 연동 후 교체
-const MOCK_MEETING = {
-  id: 1,
-  userId: 1, // 작성자(운영진) id — currentUserId와 비교해 본인 여부 판단
-  category: "모임",
-  done: false, // 모집 중
-  title: "여름 워크샵 1박 2일 MT",
-  author: "34기 씨부엉",
-  date: "2026. 01. 30",
-  views: 122,
-  time: "2026.04.20 (토) 18:00",
-  location: "학교 후문 OO치킨 2층",
-  content: `안녕하세요, 운영진입니다. 이번 신입 환영회 일정을 공유합니다.
+function fmt(iso?: string, pattern = "yyyy.MM.dd (EEE) HH:mm") {
+  if (!iso) return "-";
+  try {
+    return format(new Date(iso), pattern, { locale: ko });
+  } catch {
+    return iso;
+  }
+}
 
-‣ 일시 : 2026.04.20 (토) 오후 6시
-‣ 장소 : 학교 후문 'OO치킨' 2층
-‣ 회비 : 인당 18,000원 (현장 수령)
-‣ 응답 마감 : 2026.04.17 (목) 자정
-
-※ 신입부원은 웰컴 조용하게 있다가 관점하셔도 됩니다 — 자유 참석이에요 :)`,
-  capacity: 15,
-};
-
-type VoteKey = "yes" | "no" | "maybe";
-
-const VOTE_OPTIONS: { key: VoteKey; label: string; emotion: MascotEmotion }[] = [
-  { key: "yes", label: "참석할게요", emotion: "default" },
-  { key: "no", label: "참석이 어려워요", emotion: "sad" },
-  { key: "maybe", label: "미정이에요", emotion: "working" },
-];
-
-// 투표 결과(데모) — API 연동 시 교체
-type Member = { gen: string; name: string };
-
-// 본인(데모) — API 연동 시 로그인 사용자로 교체. 내 선택에 따라 아래 그룹에 포함된다.
-const ME: Member = { gen: "15기", name: "김민주" };
-
-// 나를 제외한 다른 부원들의 응답(고정). 내 투표를 바꾸면 내가 해당 그룹으로 이동한다.
-const VOTE_GROUPS: {
-  key: VoteKey;
-  en: string;
-  ko: string;
-  tone: string;
-  base: Member[];
+// 참석 투표 — 서버는 PASS/FAIL 2지선다. (UNDECIDED/미정 투표는 서버 미지원)
+const VOTE_OPTIONS: {
+  key: VoteDecision;
+  label: string;
+  emotion: MascotEmotion;
 }[] = [
-  {
-    key: "yes",
-    en: "Approval",
-    ko: "참석 가능",
-    tone: "text-success",
-    base: [
-      { gen: "14기", name: "이서연" }, { gen: "14기", name: "절준호" },
-      { gen: "14기", name: "윤지우" }, { gen: "14기", name: "고은성" },
-      { gen: "15기", name: "강성주" }, { gen: "15기", name: "김건우" },
-      { gen: "15기", name: "박도윤" }, { gen: "15기", name: "강남규" },
-      { gen: "15기", name: "김광현" }, { gen: "15기", name: "정하은" },
-      { gen: "15기", name: "이도현" },
-    ],
-  },
-  {
-    key: "no",
-    en: "Negative",
-    ko: "참석 불가능",
-    tone: "text-danger",
-    base: [
-      { gen: "14기", name: "강순철" }, { gen: "14기", name: "김가연" },
-      { gen: "15기", name: "강여진" },
-    ],
-  },
-  {
-    key: "maybe",
-    en: "Waiting",
-    ko: "참석 대기",
-    tone: "text-waiting",
-    base: [
-      { gen: "14기", name: "장잇프" }, { gen: "14기", name: "명자동구" },
-      { gen: "15기", name: "고은성" },
-    ],
-  },
+  { key: "PASS", label: "참석할게요", emotion: "default" },
+  { key: "FAIL", label: "참석이 어려워요", emotion: "sad" },
 ];
 
-function MemberList({ members, highlight }: { members: Member[]; highlight?: Member }) {
+function MemberList({ members }: { members: GatheringMember[] }) {
+  if (members.length === 0) {
+    return <p className="mt-4 text-sm text-gray-400">아직 없어요</p>;
+  }
   return (
     <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3">
-      {members.map((m) => {
-        const isMe =
-          highlight && m.gen === highlight.gen && m.name === highlight.name;
-        return (
-          <div key={`${m.gen}-${m.name}`} className="flex items-center gap-2">
-            <span
-              className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium ${
-                isMe ? "bg-success/15 text-success" : "bg-gray-100 text-gray-500"
-              }`}
-            >
-              {m.gen}
-            </span>
-            <span
-              className={`text-sm ${
-                isMe ? "font-semibold text-gray-900" : "text-gray-700"
-              }`}
-            >
-              {m.name}
-              {isMe ? " (나)" : ""}
-            </span>
-          </div>
-        );
-      })}
+      {members.map((m) => (
+        <div key={m.memberId} className="flex items-center gap-2">
+          <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+            {m.generation}기
+          </span>
+          <span className="text-sm text-gray-700">{m.name}</span>
+        </div>
+      ))}
     </div>
   );
 }
 
 export default function MeetingDetailPage() {
   const router = useRouter();
-  const [choice, setChoice] = useState<VoteKey | null>(null);
-  const [voted, setVoted] = useState(false);
+  const params = useParams();
+  const id = Number(params?.id);
+  const isStaff = useIsStaff();
 
-  const userId = useUserStore((s) => s.userId);
-  const currentUserId = userId ? Number(userId) : null;
-  const isAuthor = currentUserId != null && currentUserId === MOCK_MEETING.userId;
+  const { data: meeting, isLoading, isError } = useGathering(id || null);
+  const { data: attendance } = useAttendance(id || null);
+  const voteMutation = useVoteGathering(id);
+  const deleteMutation = useDeleteGathering();
+  const closeMutation = useCloseGathering(id);
+
+  // 내 기존 투표를 기본 선택으로 파생, 사용자가 바꾸면 override 우선
+  const [choiceOverride, setChoiceOverride] = useState<VoteDecision | null>(
+    null,
+  );
+
+  if (isLoading) {
+    return (
+      <RequireMember>
+        <main className="container-x-lg py-20 text-center text-gray-400">
+          모임을 불러오는 중...
+        </main>
+      </RequireMember>
+    );
+  }
+  if (isError || !meeting) {
+    return (
+      <RequireMember>
+        <main className="container-x-lg py-20 text-center text-red-500">
+          <p>모임을 불러오지 못했습니다.</p>
+          <button
+            onClick={() => router.push("/meeting")}
+            className="mt-3 text-sm text-gray-500 underline"
+          >
+            목록으로
+          </button>
+        </main>
+      </RequireMember>
+    );
+  }
+
+  const defaultChoice: VoteDecision | null =
+    meeting.myStatus === "ATTENDING"
+      ? "PASS"
+      : meeting.myStatus === "NOT_ATTENDING"
+        ? "FAIL"
+        : null;
+  const choice = choiceOverride ?? defaultChoice;
+
+  const handleDelete = () => {
+    if (!window.confirm("이 모임을 삭제할까요?")) return;
+    deleteMutation.mutate(id, { onSuccess: () => router.push("/meeting") });
+  };
+
+  const handleClose = () => {
+    if (
+      !window.confirm("투표를 마감할까요? 마감 후에는 응답을 받을 수 없어요.")
+    )
+      return;
+    closeMutation.mutate();
+  };
+
+  const handleVote = () => {
+    if (!choice) return;
+    voteMutation.mutate(choice);
+  };
 
   return (
     <RequireMember>
       <main className="min-h-screen pb-16 bg-white">
         <div className="container-x-lg">
           <div className="pt-6 lg:pt-12">
-            {/* 상단 바 — 목록으로 / 더보기 */}
+            {/* 상단 바 */}
             <div className="flex items-center justify-between mb-6">
               <button
                 onClick={() => router.push("/meeting")}
@@ -142,134 +141,170 @@ export default function MeetingDetailPage() {
               >
                 <ChevronLeft size={16} /> 목록으로
               </button>
-              <KebabMenu
-                onEdit={isAuthor ? () => router.push("/meeting/write") : undefined}
-                onDelete={
-                  isAuthor
-                    ? () => {
-                        if (window.confirm("이 모임을 삭제할까요?")) router.push("/meeting");
-                      }
-                    : undefined
-                }
-              />
+              {isStaff && (
+                <KebabMenu
+                  onEdit={() => router.push(`/meeting/write?id=${id}`)}
+                  onDelete={handleDelete}
+                />
+              )}
             </div>
 
             {/* 분류 / 상태 / 제목 / 작성자 / 메타 */}
             <div className="flex items-center gap-2">
               <span className="inline-flex items-center rounded-full bg-pink-50 px-3 py-1 text-xs font-semibold text-pink-500">
-                {MOCK_MEETING.category}
+                {GATHERING_TYPE_LABEL[meeting.type]}
               </span>
-              <StatusBadge tone={MOCK_MEETING.done ? "danger" : "success"}>
-                {MOCK_MEETING.done ? "모집 완료" : "모집 중"}
+              <StatusBadge tone={meeting.voteClosed ? "danger" : "success"}>
+                {meeting.voteClosed ? "모집 완료" : "모집 중"}
               </StatusBadge>
             </div>
-            <h1 className="mt-4 text-2xl font-bold text-gray-900">{MOCK_MEETING.title}</h1>
-            <p className="mt-3 text-base text-gray-600">{MOCK_MEETING.author}</p>
+            <h1 className="mt-4 text-2xl font-bold text-gray-900">
+              {meeting.title}
+            </h1>
+            <p className="mt-3 text-base text-gray-600">
+              {meeting.authorGeneration}기 {meeting.authorName}
+            </p>
             <div className="mt-2 flex items-center gap-4 text-sm text-gray-600">
               <span className="flex items-center gap-1">
-                <Clock size={14} /> {MOCK_MEETING.date}
+                <Clock size={14} /> {fmt(meeting.createdAt, "yyyy.MM.dd")}
               </span>
               <span className="flex items-center gap-1">
-                <Eye size={14} /> {MOCK_MEETING.views}
+                <Eye size={14} /> {meeting.viewCount}
               </span>
             </div>
 
-            {/* 시간 / 장소 정보 카드 */}
+            {/* 시간 / 장소 */}
             <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="flex items-center gap-4 rounded-2xl border border-gray-200 px-5 py-4 text-sm">
                 <span className="flex items-center gap-2 font-medium text-gray-700">
                   <Clock size={16} className="text-gray-400" /> 시간
                 </span>
                 <span className="h-4 w-px bg-gray-200" />
-                <span className="text-gray-900">{MOCK_MEETING.time}</span>
+                <span className="text-gray-900">
+                  {fmt(meeting.gatheringDate)}
+                </span>
               </div>
               <div className="flex items-center gap-4 rounded-2xl border border-gray-200 px-5 py-4 text-sm">
                 <span className="flex items-center gap-2 font-medium text-gray-700">
                   <MapPin size={16} className="text-gray-400" /> 장소
                 </span>
                 <span className="h-4 w-px bg-gray-200" />
-                <span className="text-gray-900">{MOCK_MEETING.location}</span>
+                <span className="text-gray-900">{meeting.location || "-"}</span>
               </div>
             </div>
 
             {/* 본문 */}
             <div className="whitespace-pre-wrap border-t border-gray-200 mt-6 py-10 text-base leading-relaxed text-gray-900">
-              {MOCK_MEETING.content}
+              {meeting.description}
             </div>
 
-            {/* 하단 메타 */}
-            <div className="flex items-center gap-4 border-b border-gray-200 pb-6 text-sm text-gray-700">
+            {/* 응답 마감 + 운영진 마감 버튼 */}
+            <div className="flex items-center justify-between border-b border-gray-200 pb-6 text-sm text-gray-700">
               <span className="flex items-center gap-1">
-                <Clock size={16} /> {MOCK_MEETING.date}
+                <Clock size={16} /> 응답 마감 {fmt(meeting.voteDeadline)}
               </span>
-              <span className="flex items-center gap-1">
-                <Eye size={16} /> {MOCK_MEETING.views}
-              </span>
+              {isStaff && !meeting.voteClosed && (
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  disabled={closeMutation.isPending}
+                  className="rounded-full border border-gray-200 px-4 py-2 text-xs text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-40"
+                >
+                  {closeMutation.isPending ? "마감 중..." : "투표 마감"}
+                </button>
+              )}
             </div>
 
             {/* 참석 투표 */}
             <section className="mt-8 rounded-2xl bg-gray-50 p-8">
               <p className="text-sm font-semibold text-success">Vote</p>
-              <h2 className="mt-1 text-2xl font-bold text-gray-900">참석 여부를 알려주세요.</h2>
+              <h2 className="mt-1 text-2xl font-bold text-gray-900">
+                참석 여부를 알려주세요.
+              </h2>
               <p className="mt-2 text-sm text-gray-500">
-                참석 여부는 아래 버튼으로 투표해주세요 (초록 버튼 = 현재 선택)
+                {meeting.voteClosed
+                  ? "마감된 모임이에요. 응답 결과만 볼 수 있어요."
+                  : "참석 여부는 아래 버튼으로 투표해주세요 (초록 버튼 = 현재 선택)"}
               </p>
 
-              {/* 투표 버튼 */}
-              <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
-                {VOTE_OPTIONS.map((opt) => {
-                  const selected = choice === opt.key;
-                  return (
-                    <button
-                      key={opt.key}
-                      type="button"
-                      onClick={() => setChoice(opt.key)}
-                      className={`flex flex-col items-center gap-3 rounded-2xl border-2 py-8 transition-colors ${
-                        selected
-                          ? "border-success bg-[#def7eb]"
-                          : "border-gray-200 bg-white hover:border-gray-300"
-                      }`}
-                    >
-                      <Mascot emotion={opt.emotion} size="sm" decorative />
-                      <span className="text-title-lg text-gray-900">{opt.label}</span>
-                    </button>
-                  );
-                })}
-              </div>
-
-              {/* 투표 전: 제출하기 / 투표 후: 응답 명단 (버튼을 바꾸면 내가 해당 그룹으로 이동) */}
-              {!voted ? (
-                <button
-                  type="button"
-                  disabled={!choice}
-                  onClick={() => setVoted(true)}
-                  className="mt-4 w-full rounded-full bg-gradient-to-b from-[#48c281] to-[#58d4c5] py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  제출하기
-                </button>
-              ) : (
-                <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
-                  {VOTE_GROUPS.map((g) => {
-                    // 내가 고른 그룹에는 본인을 맨 위에 추가 → 선택 변경 시 명단·인원수 즉시 갱신
-                    const members = choice === g.key ? [ME, ...g.base] : g.base;
-                    return (
-                      <div
-                        key={g.key}
-                        className="rounded-2xl border border-gray-100 bg-white p-5"
-                      >
-                        <div className="flex items-baseline justify-between">
-                          <div>
-                            <p className={`text-sm font-bold ${g.tone}`}>{g.en}</p>
-                            <p className="text-lg font-bold text-gray-900">{g.ko}</p>
-                          </div>
-                          <span className="text-lg font-bold text-gray-900">
-                            {members.length}명
+              {!meeting.voteClosed && (
+                <>
+                  <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    {VOTE_OPTIONS.map((opt) => {
+                      const selected = choice === opt.key;
+                      return (
+                        <button
+                          key={opt.key}
+                          type="button"
+                          onClick={() => setChoiceOverride(opt.key)}
+                          className={`flex flex-col items-center gap-3 rounded-2xl border-2 py-8 transition-colors ${
+                            selected
+                              ? "border-success bg-[#def7eb]"
+                              : "border-gray-200 bg-white hover:border-gray-300"
+                          }`}
+                        >
+                          <Mascot emotion={opt.emotion} size="sm" decorative />
+                          <span className="text-title-lg text-gray-900">
+                            {opt.label}
                           </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={!choice || voteMutation.isPending}
+                    onClick={handleVote}
+                    className="mt-4 w-full rounded-full bg-gradient-to-b from-[#48c281] to-[#58d4c5] py-4 text-headline-sm text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    {voteMutation.isPending ? "제출 중..." : "제출하기"}
+                  </button>
+                </>
+              )}
+
+              {/* 응답 명단 */}
+              {attendance && (
+                <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  {[
+                    {
+                      ko: "참석 가능",
+                      en: "Approval",
+                      tone: "text-success",
+                      list: attendance.attendingMembers,
+                    },
+                    {
+                      ko: "참석 불가능",
+                      en: "Negative",
+                      tone: "text-danger",
+                      list: attendance.notAttendingMembers,
+                    },
+                    {
+                      ko: "미정",
+                      en: "Waiting",
+                      tone: "text-waiting",
+                      list: attendance.undecidedMembers,
+                    },
+                  ].map((g) => (
+                    <div
+                      key={g.en}
+                      className="rounded-2xl border border-gray-100 bg-white p-5"
+                    >
+                      <div className="flex items-baseline justify-between">
+                        <div>
+                          <p className={`text-sm font-bold ${g.tone}`}>
+                            {g.en}
+                          </p>
+                          <p className="text-lg font-bold text-gray-900">
+                            {g.ko}
+                          </p>
                         </div>
-                        <MemberList members={members} highlight={ME} />
+                        <span className="text-lg font-bold text-gray-900">
+                          {g.list.length}명
+                        </span>
                       </div>
-                    );
-                  })}
+                      <MemberList members={g.list} />
+                    </div>
+                  ))}
                 </div>
               )}
             </section>

--- a/src/app/meeting/page.tsx
+++ b/src/app/meeting/page.tsx
@@ -45,10 +45,9 @@ export default function MeetingPage() {
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
-  const paged = filtered.slice(
-    (currentPage - 1) * PAGE_SIZE,
-    currentPage * PAGE_SIZE,
-  );
+  // 목록이 줄어(삭제·재검증 등) currentPage가 범위를 넘으면 마지막 페이지로 보정
+  const page = Math.min(currentPage, totalPages);
+  const paged = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   return (
     <RequireMember>
@@ -122,7 +121,7 @@ export default function MeetingPage() {
 
               <div className="mt-10">
                 <Pagination
-                  currentPage={currentPage}
+                  currentPage={page}
                   totalPages={pageNumbers}
                   onPageChange={setCurrentPage}
                 />

--- a/src/app/meeting/page.tsx
+++ b/src/app/meeting/page.tsx
@@ -1,57 +1,55 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Pencil } from "lucide-react";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 import RequireMember from "@/components/auth/RequireMember";
 import Pagination from "@/components/shared/Pagination";
 import Tabs from "@/components/common/Tabs";
 import MeetingCard from "@/components/meeting/MeetingCard";
 import { useIsStaff } from "@/hooks/auth/useIsStaff";
-
-// TODO: API 연동 후 교체
-type Meeting = {
-  id: number;
-  category: string; // 모임 / MT / 회식
-  done: boolean; // false=모집 중(진행 예정), true=모집 완료(지난 모임)
-  title: string;
-  date: string;
-  location: string;
-  responded: number; // 참석 응답 / 최종 참석 인원
-  capacity: number; // 정원
-};
-
-const MOCK_MEETINGS: Meeting[] = [
-  { id: 1, category: "모임", done: false, title: "2026 봄학기 신입 환영회", date: "2026.04.20 (토) 18:00", location: "학교 후문 OO치킨 2층", responded: 16, capacity: 15 },
-  { id: 2, category: "MT", done: false, title: "여름 워크샵 1박 2일 MT", date: "2026.06.15 (월) 09:00 ~ 06.16 (화)", location: "가평 OO펜션 전관", responded: 12, capacity: 15 },
-  { id: 3, category: "회식", done: true, title: "3월 친목 도모 회식", date: "2026.03.28 (금) 19:00", location: "종강 펌 본점", responded: 12, capacity: 15 },
-  { id: 4, category: "모임", done: false, title: "4월 정기 모임 — 프로젝트 중간 공유", date: "2026.04.12 (토) 14:00", location: "동아리방 (공학관 401)", responded: 9, capacity: 15 },
-  { id: 5, category: "MT", done: false, title: "신입 환영 단합 MT", date: "2026.05.10 (토) 10:00 ~ 05.11 (일)", location: "양평 OO글램핑", responded: 14, capacity: 15 },
-  { id: 6, category: "회식", done: true, title: "해커톤 뒷풀이 회식", date: "2026.03.15 (토) 20:00", location: "정자동 OO포차", responded: 18, capacity: 20 },
-  { id: 7, category: "모임", done: false, title: "5월 정기 세미나 + 번개 모임", date: "2026.05.02 (금) 19:00", location: "동아리방 (공학관 401)", responded: 7, capacity: 15 },
-  { id: 8, category: "회식", done: true, title: "2월 종강 기념 회식", date: "2026.02.21 (금) 18:30", location: "야탑 OO고깃집", responded: 15, capacity: 15 },
-  { id: 9, category: "MT", done: false, title: "임원진 워크샵", date: "2026.05.24 (토) 13:00", location: "수원 OO세미나실", responded: 8, capacity: 10 },
-  { id: 10, category: "모임", done: false, title: "졸업 선배 초청 네트워킹", date: "2026.05.30 (금) 18:00", location: "교내 창업보육센터", responded: 11, capacity: 20 },
-  { id: 11, category: "회식", done: true, title: "1월 신년 모임", date: "2026.01.10 (금) 18:00", location: "강남 OO이자카야", responded: 13, capacity: 15 },
-];
+import { useGatherings } from "@/hooks/meeting";
+import { GATHERING_TYPE_LABEL } from "@/api";
 
 type StatusTab = "전체" | "진행 예정" | "지난 모임";
+
+const PAGE_SIZE = 12; // 3열 × 4행
+
+function formatDate(iso: string) {
+  try {
+    return format(new Date(iso), "yyyy.MM.dd (EEE) HH:mm", { locale: ko });
+  } catch {
+    return iso;
+  }
+}
 
 export default function MeetingPage() {
   const isStaff = useIsStaff();
   const [activeTab, setActiveTab] = useState<StatusTab>("전체");
   const [currentPage, setCurrentPage] = useState(1);
-  // 페이지당 최대 12개 (3열 × 4행). API 연동 시 size=12로 요청.
-  const totalPages = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-  const upcomingCount = MOCK_MEETINGS.filter((m) => !m.done).length;
-  const pastCount = MOCK_MEETINGS.filter((m) => m.done).length;
+  const { data: gatherings = [], isLoading, isError } = useGatherings();
 
-  const filtered = MOCK_MEETINGS.filter((m) => {
-    if (activeTab === "진행 예정") return !m.done;
-    if (activeTab === "지난 모임") return m.done;
-    return true;
-  });
+  const upcomingCount = gatherings.filter((m) => !m.voteClosed).length;
+  const pastCount = gatherings.filter((m) => m.voteClosed).length;
+
+  const filtered = useMemo(() => {
+    const list = gatherings.filter((m) => {
+      if (activeTab === "진행 예정") return !m.voteClosed;
+      if (activeTab === "지난 모임") return m.voteClosed;
+      return true;
+    });
+    return list;
+  }, [gatherings, activeTab]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const paged = filtered.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
+  );
 
   return (
     <RequireMember>
@@ -73,7 +71,10 @@ export default function MeetingPage() {
                 { label: `지난 모임 (${pastCount})`, value: "지난 모임" },
               ]}
               value={activeTab}
-              onValueChange={(v) => setActiveTab(v as StatusTab)}
+              onValueChange={(v) => {
+                setActiveTab(v as StatusTab);
+                setCurrentPage(1);
+              }}
             />
             {isStaff && (
               <Link
@@ -85,26 +86,50 @@ export default function MeetingPage() {
             )}
           </div>
 
-          {/* 카드 그리드 — 3열 × 4행 = 최대 12개 */}
-          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
-            {filtered.map((m) => (
-              <MeetingCard
-                key={m.id}
-                href={`/meeting/${m.id}`}
-                category={m.category}
-                done={m.done}
-                title={m.title}
-                date={m.date}
-                location={m.location}
-                responded={m.responded}
-                capacity={m.capacity}
-              />
-            ))}
-          </div>
+          {isLoading && (
+            <div className="py-20 text-center text-gray-400">
+              모임을 불러오는 중...
+            </div>
+          )}
+          {isError && (
+            <div className="py-20 text-center text-red-500">
+              모임 목록을 불러오지 못했습니다.
+            </div>
+          )}
 
-          <div className="mt-10">
-            <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setCurrentPage} />
-          </div>
+          {!isLoading && !isError && filtered.length === 0 && (
+            <div className="py-20 text-center text-gray-400">
+              등록된 모임이 없어요.
+            </div>
+          )}
+
+          {!isLoading && !isError && filtered.length > 0 && (
+            <>
+              <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+                {paged.map((m) => (
+                  <MeetingCard
+                    key={m.id}
+                    href={`/meeting/${m.id}`}
+                    category={GATHERING_TYPE_LABEL[m.type]}
+                    done={m.voteClosed}
+                    title={m.title}
+                    date={formatDate(m.gatheringDate)}
+                    location={m.location}
+                    responded={m.summary.attending}
+                    capacity={m.summary.total}
+                  />
+                ))}
+              </div>
+
+              <div className="mt-10">
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={pageNumbers}
+                  onPageChange={setCurrentPage}
+                />
+              </div>
+            </>
+          )}
         </div>
       </main>
     </RequireMember>

--- a/src/app/meeting/page.tsx
+++ b/src/app/meeting/page.tsx
@@ -9,8 +9,7 @@ import RequireMember from "@/components/auth/RequireMember";
 import Pagination from "@/components/shared/Pagination";
 import Tabs from "@/components/common/Tabs";
 import MeetingCard from "@/components/meeting/MeetingCard";
-import { useIsStaff } from "@/hooks/auth/useIsStaff";
-import { useGatherings } from "@/hooks/meeting";
+import { useGatherings, useCanManageGathering } from "@/hooks/meeting";
 import { GATHERING_TYPE_LABEL } from "@/api";
 
 type StatusTab = "전체" | "진행 예정" | "지난 모임";
@@ -26,7 +25,7 @@ function formatDate(iso: string) {
 }
 
 export default function MeetingPage() {
-  const isStaff = useIsStaff();
+  const canManage = useCanManageGathering();
   const [activeTab, setActiveTab] = useState<StatusTab>("전체");
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -76,7 +75,7 @@ export default function MeetingPage() {
                 setCurrentPage(1);
               }}
             />
-            {isStaff && (
+            {canManage && (
               <Link
                 href="/meeting/write"
                 className="flex shrink-0 items-center gap-2 rounded-full bg-gray-800 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700"

--- a/src/app/meeting/write/page.tsx
+++ b/src/app/meeting/write/page.tsx
@@ -1,33 +1,104 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import { ChevronDown, Paperclip, Monitor } from "lucide-react";
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ChevronDown } from "lucide-react";
 import RequireMember from "@/components/auth/RequireMember";
-import { useIsStaff } from "@/hooks/auth/useIsStaff";
 import Mascot from "@/components/common/Mascot";
+import { useIsStaff } from "@/hooks/auth/useIsStaff";
+import {
+  useGathering,
+  useCreateGathering,
+  useUpdateGathering,
+} from "@/hooks/meeting";
+import type { GatheringType } from "@/api";
 
-const CATEGORIES = ["모임", "MT", "회식", "박람회", "행사"];
+const TYPE_OPTIONS: { value: GatheringType; label: string }[] = [
+  { value: "OTHER", label: "모임" },
+  { value: "MT", label: "MT" },
+  { value: "DINING", label: "회식" },
+  { value: "FAIR", label: "박람회" },
+  { value: "EVENT", label: "행사" },
+];
 
-export default function MeetingWritePage() {
+/** datetime-local ↔ ISO 변환용 (앞 16자: yyyy-MM-ddTHH:mm) */
+const toLocalInput = (iso?: string) => (iso ? iso.slice(0, 16) : "");
+
+function MeetingWriteInner() {
   const router = useRouter();
   const isStaff = useIsStaff();
+  const searchParams = useSearchParams();
+  const editId = searchParams.get("id");
+  const isEdit = editId != null;
+  const gatheringId = isEdit ? Number(editId) : null;
+
+  const { data: existing } = useGathering(gatheringId);
+  const createMutation = useCreateGathering();
+  const updateMutation = useUpdateGathering(gatheringId ?? -1);
 
   const [title, setTitle] = useState("");
-  const [category, setCategory] = useState("");
-  const [datetime, setDatetime] = useState("");
+  const [type, setType] = useState<GatheringType | "">("");
+  const [gatheringDate, setGatheringDate] = useState("");
+  const [voteDeadline, setVoteDeadline] = useState("");
   const [location, setLocation] = useState("");
-  const [done, setDone] = useState(false); // false=모집 중, true=모집 완료
-  const [content, setContent] = useState("");
+  const [allMembersTarget, setAllMembersTarget] = useState(true);
+  const [description, setDescription] = useState("");
 
-  // 운영진만 모임 등록 가능
+  // 수정 진입 시 기존 값 채우기 (effect 내 동기 setState 회피 위해 microtask)
+  useEffect(() => {
+    if (!existing) return;
+    queueMicrotask(() => {
+      setTitle(existing.title);
+      setType(existing.type);
+      setGatheringDate(toLocalInput(existing.gatheringDate));
+      setVoteDeadline(toLocalInput(existing.voteDeadline));
+      setLocation(existing.location ?? "");
+      setAllMembersTarget(existing.allMembersTarget);
+      setDescription(existing.description ?? "");
+    });
+  }, [existing]);
+
+  const canSubmit = title && type && gatheringDate && voteDeadline;
+  const pending = createMutation.isPending || updateMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit || !type) return;
+    const base = {
+      title,
+      type,
+      description,
+      gatheringDate,
+      location,
+      voteDeadline,
+    };
+    if (isEdit) {
+      updateMutation.mutate(base, {
+        onSuccess: () => router.push(`/meeting/${gatheringId}`),
+        onError: () => alert("수정 중 오류가 발생했습니다."),
+      });
+    } else {
+      createMutation.mutate(
+        { ...base, allMembersTarget },
+        {
+          onSuccess: () => router.push("/meeting"),
+          onError: () => alert("등록 중 오류가 발생했습니다."),
+        },
+      );
+    }
+  };
+
+  // 운영진만 등록/수정 가능
   if (!isStaff) {
     return (
       <RequireMember>
         <main className="container-x-lg flex min-h-[60vh] flex-col items-center justify-center text-center">
           <Mascot emotion="sad" size="md" />
-          <h1 className="mt-6 text-xl font-bold text-gray-900">운영진만 등록할 수 있어요</h1>
-          <p className="mt-2 text-sm text-gray-500">모임 일정은 운영진이 등록합니다.</p>
+          <h1 className="mt-6 text-xl font-bold text-gray-900">
+            운영진만 등록할 수 있어요
+          </h1>
+          <p className="mt-2 text-sm text-gray-500">
+            모임 일정은 운영진이 등록합니다.
+          </p>
           <button
             onClick={() => router.push("/meeting")}
             className="mt-6 rounded-full border border-gray-200 px-6 py-2.5 text-sm text-gray-600 transition-colors hover:bg-gray-50"
@@ -43,24 +114,29 @@ export default function MeetingWritePage() {
     <RequireMember>
       <main className="min-h-screen pb-16 bg-white">
         <div className="container-x-lg pt-6 lg:pt-12">
-          {/* 헤더 */}
           <nav className="text-sm text-gray-400">
-            <button onClick={() => router.push("/meeting")} className="hover:text-gray-600">
+            <button
+              onClick={() => router.push("/meeting")}
+              className="hover:text-gray-600"
+            >
               모임
             </button>
             <span className="mx-1.5">›</span>
-            <span className="text-gray-600">새 모임 등록</span>
+            <span className="text-gray-600">
+              {isEdit ? "모임 수정" : "새 모임 등록"}
+            </span>
           </nav>
           <div className="mt-2 flex items-end justify-between border-b border-gray-900 pb-4">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">새 모임 등록</h1>
+              <h1 className="text-2xl font-bold text-gray-900">
+                {isEdit ? "모임 수정" : "새 모임 등록"}
+              </h1>
               <p className="mt-1 text-sm text-gray-400">
                 운영진만 등록 가능 · 등록 시 전 회원에게 알림
               </p>
             </div>
           </div>
 
-          {/* 모임 정보 카드 */}
           <div className="mt-6 rounded-2xl border border-gray-200 p-6">
             <input
               value={title}
@@ -73,21 +149,27 @@ export default function MeetingWritePage() {
             <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-2">
               {/* 카테고리 */}
               <div>
-                <label className="mb-2 block text-sm font-semibold text-gray-900">카테고리</label>
+                <label className="mb-2 block text-sm font-semibold text-gray-900">
+                  카테고리
+                </label>
                 <div className="relative">
                   <select
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value)}
+                    value={type}
+                    onChange={(e) => setType(e.target.value as GatheringType)}
                     className={`w-full appearance-none rounded-xl border border-gray-200 px-4 py-3 text-sm focus:outline-none ${
-                      category ? "text-gray-900" : "text-gray-400"
+                      type ? "text-gray-900" : "text-gray-400"
                     }`}
                   >
                     <option value="" disabled>
                       카테고리를 선택해주세요
                     </option>
-                    {CATEGORIES.map((c) => (
-                      <option key={c} value={c} className="text-gray-900">
-                        {c}
+                    {TYPE_OPTIONS.map((c) => (
+                      <option
+                        key={c.value}
+                        value={c.value}
+                        className="text-gray-900"
+                      >
+                        {c.label}
                       </option>
                     ))}
                   </select>
@@ -98,20 +180,37 @@ export default function MeetingWritePage() {
                 </div>
               </div>
 
-              {/* 일시 */}
+              {/* 모임 일시 */}
               <div>
-                <label className="mb-2 block text-sm font-semibold text-gray-900">일시</label>
+                <label className="mb-2 block text-sm font-semibold text-gray-900">
+                  모임 일시
+                </label>
                 <input
                   type="datetime-local"
-                  value={datetime}
-                  onChange={(e) => setDatetime(e.target.value)}
+                  value={gatheringDate}
+                  onChange={(e) => setGatheringDate(e.target.value)}
+                  className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 focus:outline-none"
+                />
+              </div>
+
+              {/* 응답 마감 */}
+              <div>
+                <label className="mb-2 block text-sm font-semibold text-gray-900">
+                  응답 마감
+                </label>
+                <input
+                  type="datetime-local"
+                  value={voteDeadline}
+                  onChange={(e) => setVoteDeadline(e.target.value)}
                   className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 focus:outline-none"
                 />
               </div>
 
               {/* 장소 */}
               <div>
-                <label className="mb-2 block text-sm font-semibold text-gray-900">장소</label>
+                <label className="mb-2 block text-sm font-semibold text-gray-900">
+                  장소
+                </label>
                 <input
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
@@ -119,60 +218,35 @@ export default function MeetingWritePage() {
                   className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
                 />
               </div>
-
-              {/* 모집 상태 */}
-              <div>
-                <label className="mb-2 block text-sm font-semibold text-gray-900">모집 상태</label>
-                <div className="inline-flex rounded-full bg-gray-100 p-1">
-                  <button
-                    type="button"
-                    onClick={() => setDone(false)}
-                    className={`rounded-full px-5 py-2 text-sm font-medium transition-colors ${
-                      !done ? "bg-white text-gray-900 shadow-sm" : "text-gray-400"
-                    }`}
-                  >
-                    모집 중
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setDone(true)}
-                    className={`rounded-full px-5 py-2 text-sm font-medium transition-colors ${
-                      done ? "bg-white text-gray-900 shadow-sm" : "text-gray-400"
-                    }`}
-                  >
-                    모집 완료
-                  </button>
-                </div>
-              </div>
             </div>
+
+            {/* 전 회원 대상 (등록 시에만) */}
+            {!isEdit && (
+              <label className="mt-6 flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={allMembersTarget}
+                  onChange={(e) => setAllMembersTarget(e.target.checked)}
+                  className="size-4 accent-brand"
+                />
+                전 회원 대상 모임
+              </label>
+            )}
           </div>
 
           {/* 본문 */}
           <div className="mt-6 rounded-2xl border border-gray-200 p-6">
             <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
               maxLength={10000}
               rows={14}
               placeholder="모임 설명, 장소 상세, 회비, 준비물 등을 자유롭게 입력하세요…"
               className="w-full resize-none text-sm leading-relaxed text-gray-900 placeholder-gray-400 focus:outline-none"
             />
-            <div className="mt-2 text-right text-xs text-gray-400">{content.length} / 10,000</div>
-          </div>
-
-          {/* 파일 첨부 */}
-          <div className="mt-6 rounded-2xl border border-gray-200 p-6">
-            <p className="text-sm font-semibold text-gray-900">파일 첨부 (선택)</p>
-            <label className="mt-3 flex cursor-pointer items-center justify-between rounded-xl bg-gray-50 px-5 py-4 text-sm text-gray-400">
-              <span className="flex items-center gap-2">
-                <Paperclip size={16} />
-                버튼 선택 또는 첨부파일을 이곳에 드래그&드롭해 주세요.
-              </span>
-              <span className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-600">
-                <Monitor size={14} /> 내 컴퓨터 찾기
-              </span>
-              <input type="file" multiple className="hidden" />
-            </label>
+            <div className="mt-2 text-right text-xs text-gray-400">
+              {description.length} / 10,000
+            </div>
           </div>
 
           {/* 푸터 */}
@@ -186,14 +260,23 @@ export default function MeetingWritePage() {
             </button>
             <button
               type="button"
-              onClick={() => router.push("/meeting")}
-              className="rounded-full bg-gray-800 px-7 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700"
+              disabled={!canSubmit || pending}
+              onClick={handleSubmit}
+              className="rounded-full bg-gray-800 px-7 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700 disabled:opacity-40"
             >
-              게시하기
+              {pending ? "저장 중..." : isEdit ? "수정하기" : "게시하기"}
             </button>
           </div>
         </div>
       </main>
     </RequireMember>
+  );
+}
+
+export default function MeetingWritePage() {
+  return (
+    <Suspense fallback={null}>
+      <MeetingWriteInner />
+    </Suspense>
   );
 }

--- a/src/app/meeting/write/page.tsx
+++ b/src/app/meeting/write/page.tsx
@@ -5,11 +5,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import RequireMember from "@/components/auth/RequireMember";
 import Mascot from "@/components/common/Mascot";
-import { useIsStaff } from "@/hooks/auth/useIsStaff";
 import {
   useGathering,
   useCreateGathering,
   useUpdateGathering,
+  useCanManageGathering,
 } from "@/hooks/meeting";
 import type { GatheringType } from "@/api";
 
@@ -26,7 +26,7 @@ const toLocalInput = (iso?: string) => (iso ? iso.slice(0, 16) : "");
 
 function MeetingWriteInner() {
   const router = useRouter();
-  const isStaff = useIsStaff();
+  const canManage = useCanManageGathering();
   const searchParams = useSearchParams();
   const editId = searchParams.get("id");
   const isEdit = editId != null;
@@ -88,7 +88,7 @@ function MeetingWriteInner() {
   };
 
   // 운영진만 등록/수정 가능
-  if (!isStaff) {
+  if (!canManage) {
     return (
       <RequireMember>
         <main className="container-x-lg flex min-h-[60vh] flex-col items-center justify-center text-center">

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from "./mail";
 export * from "./project";
 export * from "./board";
 export * from "./news";
+export * from "./meeting";

--- a/src/hooks/meeting/index.ts
+++ b/src/hooks/meeting/index.ts
@@ -8,3 +8,4 @@ export {
   useVoteGathering,
   useCloseGathering,
 } from "./useGatherings";
+export { useCanManageGathering } from "./useCanManageGathering";

--- a/src/hooks/meeting/index.ts
+++ b/src/hooks/meeting/index.ts
@@ -1,0 +1,10 @@
+export {
+  useGatherings,
+  useGathering,
+  useAttendance,
+  useCreateGathering,
+  useUpdateGathering,
+  useDeleteGathering,
+  useVoteGathering,
+  useCloseGathering,
+} from "./useGatherings";

--- a/src/hooks/meeting/useCanManageGathering.ts
+++ b/src/hooks/meeting/useCanManageGathering.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useUserStore } from "@/store/userStore";
+
+/** 모임 등록/수정/삭제/마감 허용 역할 (서버 기준): 개발자관리자·회장·부회장·행사관리 */
+const MANAGER_ROLES = [
+  "ROLE_ADMIN",
+  "ROLE_PRESIDENT",
+  "ROLE_VICE_PRESIDENT",
+  "ROLE_EVENT_MANAGER",
+];
+
+/**
+ * 모임을 관리(등록/수정/삭제/마감)할 수 있는지 — 버튼 노출 게이팅용.
+ * ⚠️ UI 노출 전용. 실제 접근은 서버가 최종 판정(401/403).
+ */
+export function useCanManageGathering() {
+  const role = useUserStore((s) => s.role);
+  const isAdmin = useUserStore((s) => s.isAdmin);
+  return isAdmin || MANAGER_ROLES.includes(role);
+}

--- a/src/hooks/meeting/useGatherings.ts
+++ b/src/hooks/meeting/useGatherings.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  gatheringApi,
+  type Gathering,
+  type AttendanceList,
+  type VoteDecision,
+  type CreateGatheringBody,
+  type UpdateGatheringBody,
+} from "@/api";
+
+const LIST_KEY = ["gatherings"] as const;
+const detailKey = (id: number) => ["gathering", id] as const;
+const attendanceKey = (id: number) => ["gathering", id, "attendance"] as const;
+
+/** 모임 목록 */
+export function useGatherings() {
+  return useQuery({
+    queryKey: LIST_KEY,
+    queryFn: async (): Promise<Gathering[]> =>
+      (await gatheringApi.getList()).data.data,
+  });
+}
+
+/** 모임 상세 */
+export function useGathering(id: number | null) {
+  return useQuery({
+    queryKey: detailKey(id ?? -1),
+    enabled: id != null,
+    queryFn: async (): Promise<Gathering> =>
+      (await gatheringApi.getById(id as number)).data.data,
+  });
+}
+
+/** 참석 명단 (투표 그룹) */
+export function useAttendance(id: number | null) {
+  return useQuery({
+    queryKey: attendanceKey(id ?? -1),
+    enabled: id != null,
+    queryFn: async (): Promise<AttendanceList> =>
+      (await gatheringApi.getAttendance(id as number)).data.data,
+  });
+}
+
+/** 모임 등록 */
+export function useCreateGathering() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateGatheringBody) => gatheringApi.create(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}
+
+/** 모임 수정 */
+export function useUpdateGathering(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateGatheringBody) => gatheringApi.update(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: LIST_KEY });
+      qc.invalidateQueries({ queryKey: detailKey(id) });
+    },
+  });
+}
+
+/** 모임 삭제 */
+export function useDeleteGathering() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => gatheringApi.remove(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}
+
+/** 참석 투표 */
+export function useVoteGathering(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (decision: VoteDecision) => gatheringApi.vote(id, decision),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: detailKey(id) });
+      qc.invalidateQueries({ queryKey: attendanceKey(id) });
+    },
+  });
+}
+
+/** 투표 마감 */
+export function useCloseGathering(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => gatheringApi.close(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: LIST_KEY });
+      qc.invalidateQueries({ queryKey: detailKey(id) });
+    },
+  });
+}

--- a/src/hooks/meeting/useGatherings.ts
+++ b/src/hooks/meeting/useGatherings.ts
@@ -69,7 +69,12 @@ export function useDeleteGathering() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: number) => gatheringApi.remove(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: LIST_KEY });
+      // 삭제된 항목의 상세/참석 캐시 제거 (뒤로가기 재진입 시 stale 노출 방지)
+      qc.removeQueries({ queryKey: detailKey(id) });
+      qc.removeQueries({ queryKey: attendanceKey(id) });
+    },
   });
 }
 


### PR DESCRIPTION
## 무엇
`/meeting`(부엉이 모임)을 mock → 실 API로 연결. `/gatherings` 10개 엔드포인트 전부:
목록·상세·등록·수정·삭제·참석투표·마감·참석명단(일반/관리자/엑셀).

## 왜
스웨거에 모임 API가 다 있는데 화면이 전부 하드코딩(mock)이라 실제로 동작하지 않았음. 실데이터로 연결하고 권한·상태를 스웨거 기준에 맞춤.

## 어떻게 테스트
- tsc · eslint · `npm run build` 통과
- 스웨거 스키마/경로/메서드 1:1 대조, 라이브 상태코드로 경로 존재 확인(404 없음)
- ⚠️ 런타임(투표→명단 갱신·날짜 파싱·엑셀 다운로드)은 인증 필요라 미검증 → 로컬 로그인 후 스모크 예정

## 권한 (스웨거 기준)
- 등록·수정·삭제·마감: ADMIN·회장·부회장·행사관리 (`useCanManageGathering`)
- 투표·목록·상세: 회원 누구나
- 참석명단·엑셀: 현재 BE는 ADMIN만 → 운영진 확대 **BE 요청함**

## 남은 BE 의존
- `GatheringResponse.authorId` 추가 (현재 작성자 본인 구분 없이 운영진 게이팅) — 요청함
- `/attendance/export`·`/attendance/admin` 허용 역할 확대(회장·부회장·행사관리) — 요청함
- 투표 미정 상태 제거(참석/불참만) 반영 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모임 투표, 마감, 삭제 기능 추가
  * 참석자 명단 엑셀 다운로드 기능 추가
  * 모임 등록/수정 폼 개선 (날짜/마감 시간 분리 입력)

* **Refactor**
  * 모임 목록 및 상세 페이지를 실제 API 데이터 기반으로 전환
  * 모임 관리 권한 확인 로직 개선
  * 데이터 불러오기 및 상태 관리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->