### PR TITLE
fix: 뉴스레터 주간/특집/공지 필터를 서버 사이드로 전환 

### DIFF
--- a/src/api/news.api.ts
+++ b/src/api/news.api.ts
@@ -5,11 +5,10 @@ export type NewsCategory = "NOTICE" | "EVENT" | "NEWSLETTER" | "IT_NEWS";
 
 export type NewsletterType = "WEEKLY" | "SPECIAL" | "NOTICE";
 
-// TODO(백엔드): GET /api/v1/news에 newsletterType 쿼리 파라미터(복수 지원) 추가 요청됨.
-// 추가되면 NewsListParams에 newsletterType?: NewsletterType | NewsletterType[] 필드 추가하고
-// getList 호출부(useNewsList, news/page.tsx)에서 서버 필터링으로 전환할 것.
 export type NewsListParams = {
   category?: NewsCategory | NewsCategory[];
+  // category=NEWSLETTER 안에서 주간/특집/공지 필터. 복수 지정 시 repeated 쿼리로 직렬화됨.
+  newsletterType?: NewsletterType | NewsletterType[];
   keyword?: string;
   page?: number;
   size?: number;

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -42,20 +42,14 @@ export default function NewsPage() {
 
   const { data, isLoading, isError } = useNewsList({
     category: "NEWSLETTER",
+    newsletterType: TAB_TO_TYPE[activeTab],
     keyword: submittedKeyword || undefined,
     page: currentPage,
     size: 11,
   });
 
-  // TODO(백엔드): GET /api/v1/news에 newsletterType 쿼리 필터 추가되면 이 클라이언트 필터링 제거하고
-  // useNewsList에 newsletterType 파라미터로 넘겨서 서버 페이지네이션을 그대로 쓰도록 변경할 것.
-  // 현재는 서버가 category=NEWSLETTER 기준으로 11개씩 잘라 보낸 뒤 그 안에서만 주간/특집/공지를 거르므로,
-  // 2페이지 이상에서 결과 누락·totalPages 불일치가 발생할 수 있음.
-  const allItems = data?.content ?? [];
-  const activeType = TAB_TO_TYPE[activeTab];
-  const items = activeType
-    ? allItems.filter((n) => n.newsletterType === activeType)
-    : allItems;
+  // 주간/특집/공지 필터는 서버가 처리(newsletterType) → 필터링된 결과 기준으로 페이지네이션이 계산됨.
+  const items = data?.content ?? [];
   const totalPages = data?.page?.totalPages
     ? Array.from({ length: data.page.totalPages }, (_, i) => i + 1)
     : [1];

--- a/src/hooks/news/useNewsList.ts
+++ b/src/hooks/news/useNewsList.ts
@@ -1,10 +1,16 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { newsApi, type NewsCategory, type NewsListResponse } from "@/api";
+import {
+  newsApi,
+  type NewsCategory,
+  type NewsletterType,
+  type NewsListResponse,
+} from "@/api";
 
 export type UseNewsListParams = {
   category?: NewsCategory | NewsCategory[];
+  newsletterType?: NewsletterType | NewsletterType[];
   keyword?: string;
   page: number;
   size?: number;
@@ -12,16 +18,28 @@ export type UseNewsListParams = {
 
 export function useNewsList({
   category,
+  newsletterType,
   keyword,
   page,
   size = 11,
 }: UseNewsListParams) {
   const categoryKey = Array.isArray(category) ? category.join(",") : category;
+  const newsletterTypeKey = Array.isArray(newsletterType)
+    ? newsletterType.join(",")
+    : newsletterType;
   return useQuery({
-    queryKey: ["news-list", categoryKey, keyword, page, size],
+    queryKey: [
+      "news-list",
+      categoryKey,
+      newsletterTypeKey,
+      keyword,
+      page,
+      size,
+    ],
     queryFn: async (): Promise<NewsListResponse> => {
       const res = await newsApi.getList({
         category,
+        newsletterType,
         keyword: keyword || undefined,
         page: page - 1,
         size,


### PR DESCRIPTION
- 클라이언트 사이드 필터링(.filter) 제거 → 다음 페이지로 넘어간 항목 누락·totalPages 불일치 해소
- newsListParams/useNewsList에 newsletterType(복수) 파라미터 추가, category와 동일하게 repeated 쿼리로 전송
-  #113 연동: category=NEWSLETTER + newsletterType 지정 시 필터링된 결과 기준으로 페이지네이션 계산
- notice 페이지는 원래 category 서버 필터라 영향 없음 확인

## 🔗 관련 이슈                                                                                                                                
Closes #215 

## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✨ 추가/수정 내용


## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 뉴스 목록이 탭 선택에 따라 더 정확하게 필터링되도록 개선되었습니다.
  * 주간/특집/공지 탭에서 서버 기준 결과를 사용해 목록과 페이지 수가 일치합니다.

* **Bug Fixes**
  * 클라이언트에서 별도로 걸러내던 방식으로 인해 발생할 수 있던 목록-페이지 불일치가 개선되었습니다.
  * 뉴스 조회 조건에 뉴스레터 유형이 반영되어 더 일관된 검색 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->