### PR TITLE
Feat: 모집 시작 연결 + 자유게시판 신규 명세 반영

### DIFF
--- a/src/api/applicant.api.ts
+++ b/src/api/applicant.api.ts
@@ -116,9 +116,15 @@ export type FinalizeDecision = {
 };
 
 export const recruitmentApi = {
-  /** 현재 진행 중인 모집 */
+  /** 현재 진행 중인 모집 (없으면 404) */
   getCurrent: () =>
     api.get<ApiEnvelope<Recruitment>>("/admin/recruitments/current"),
+
+  /** 모집 시작 — 시작 시점 운영진 수를 투표자 수로 고정 */
+  create: (generation: number) =>
+    api.post<ApiEnvelope<Recruitment>>("/admin/recruitments", { generation }),
+
+  // 모집 종료는 applicantApi.close 사용 (finalize flow와 한 세트)
 
   /** 모집 요약(상태별 카운트·투표 카드) */
   getSummary: (recruitmentUuid: string) =>

--- a/src/api/freeboard.api.ts
+++ b/src/api/freeboard.api.ts
@@ -12,7 +12,10 @@ export type FreeBoardUpdateBody = Partial<FreeBoardCreateBody>;
 export type FreeBoardListItem = {
   postId: number;
   title: string;
+  /** 실명 글에만 존재 (익명 글은 작성자 필드 자체가 없음) */
   authorName?: string;
+  /** 작성자 기수 — authorName과 따로 내려옴 (2026-07-02 명세: authorGeneration) */
+  authorGeneration?: number;
   authorId?: string | number;
   isAnonymous?: boolean;
   category?: string;
@@ -21,6 +24,18 @@ export type FreeBoardListItem = {
   createdAt?: string;
   [key: string]: unknown;
 };
+
+/** 작성자 표기 — 익명이면 "익명", 아니면 "{authorGeneration}기 {authorName}" */
+export function freeboardAuthorLabel(p: {
+  isAnonymous?: boolean;
+  authorName?: string;
+  authorGeneration?: number;
+}): string {
+  if (p.isAnonymous || !p.authorName) return "익명";
+  return p.authorGeneration != null
+    ? `${p.authorGeneration}기 ${p.authorName}`
+    : p.authorName;
+}
 
 export type FreeBoardListResponse = {
   content: FreeBoardListItem[];
@@ -55,4 +70,24 @@ export const freeboardApi = {
   /** 게시글 신고 */
   flag: (postId: number, content: string) =>
     api.post<ApiEnvelope<null>>(`/post/${postId}/flag`, { content }),
+
+  /**
+   * 자게 댓글 목록 — 단일 엔드포인트, 댓글별 isAnonymous로 스키마 분기
+   * (익명 댓글엔 userId/userName/generation 없음)
+   */
+  getComments: (postId: number) =>
+    api.get<{ data?: unknown }>(`/freeboard/${postId}/comment`),
+
+  /**
+   * 자게 댓글 작성 — 익명 여부는 쿼리 파라미터.
+   * 게시글 자체가 익명이면 isAnonymous 값과 무관하게 무조건 익명 처리(서버).
+   */
+  createComment: (postId: number, content: string, isAnonymous: boolean) =>
+    api.post(
+      `/freeboard/${postId}/comment`,
+      { content },
+      {
+        params: { isAnonymous },
+      },
+    ),
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -156,6 +156,7 @@ export {
 // Free Board
 export {
   freeboardApi,
+  freeboardAuthorLabel,
   type FreeBoardCreateBody,
   type FreeBoardUpdateBody,
   type FreeBoardListItem,

--- a/src/app/board/[id]/page.tsx
+++ b/src/app/board/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CommentItem } from "@/components/detail/CommentSection";
 import CommentEmpty from "@/components/detail/CommentEmpty";
 import { useIsAuthor } from "@/hooks/auth";
 import { useFreeboardDetail } from "@/hooks/board";
+import { freeboardAuthorLabel } from "@/api";
 import { useUserStore } from "@/store/userStore";
 import { formatDate } from "@/lib/date";
 import type { MappedComment } from "@/hooks/board";
@@ -22,13 +23,22 @@ export default function BoardDetailPage() {
   const params = useParams();
   const postId = Number(params.id);
   const [comment, setComment] = useState("");
-  const [anonymous, setAnonymous] = useState(true);
+  // 댓글 익명 규칙: 익명 글 → 무조건 익명(서버 강제), 실명 글 → 익명/실명 선택
+  const [anonymous, setAnonymous] = useState(false);
 
   const userId = useUserStore((s) => s.userId);
   const currentUserId = userId ? Number(userId) : null;
 
-  const { postQuery, commentsQuery, createComment, replyComment, deleteComment, deletePost, flagPost, flagComment } =
-    useFreeboardDetail(postId);
+  const {
+    postQuery,
+    commentsQuery,
+    createComment,
+    replyComment,
+    deleteComment,
+    deletePost,
+    flagPost,
+    flagComment,
+  } = useFreeboardDetail(postId);
 
   const post = postQuery.data;
   const comments = commentsQuery.data ?? [];
@@ -39,7 +49,10 @@ export default function BoardDetailPage() {
   const handleCommentSubmit = async () => {
     const trimmed = comment.trim();
     if (!trimmed || createComment.isPending) return;
-    await createComment.mutateAsync({ content: trimmed, isAnonymous: anonymous });
+    await createComment.mutateAsync({
+      content: trimmed,
+      isAnonymous: post?.isAnonymous ? true : anonymous,
+    });
     setComment("");
   };
 
@@ -67,7 +80,9 @@ export default function BoardDetailPage() {
     return (
       <RequireMember>
         <main className="min-h-screen bg-white">
-          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">
+            불러오는 중...
+          </div>
         </main>
       </RequireMember>
     );
@@ -77,7 +92,9 @@ export default function BoardDetailPage() {
     return (
       <RequireMember>
         <main className="min-h-screen bg-white">
-          <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 찾을 수 없습니다.</div>
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-500">
+            게시글을 찾을 수 없습니다.
+          </div>
         </main>
       </RequireMember>
     );
@@ -97,7 +114,11 @@ export default function BoardDetailPage() {
                 <ChevronLeft size={16} /> 목록으로
               </button>
               <KebabMenu
-                onEdit={canModify ? () => router.push(`/board/write?edit=${postId}`) : undefined}
+                onEdit={
+                  canModify
+                    ? () => router.push(`/board/write?edit=${postId}`)
+                    : undefined
+                }
                 onDelete={canModify ? handleDelete : undefined}
                 onReport={!canModify ? handleFlag : undefined}
               />
@@ -106,11 +127,12 @@ export default function BoardDetailPage() {
             {/* 제목 / 작성자 / 메타 */}
             <h1 className="mt-4 text-h1 text-gray-900">{post.title}</h1>
             <p className="mt-3 text-base text-gray-600">
-              {post.isAnonymous ? "익명" : (post.authorName ?? "")}
+              {freeboardAuthorLabel(post)}
             </p>
             <div className="mt-3 flex items-center gap-4 border-b border-gray-200 pb-6 text-sm text-gray-600">
               <span className="flex items-center gap-1">
-                <Clock size={14} /> {post.createdAt ? formatDate(post.createdAt as string) : ""}
+                <Clock size={14} />{" "}
+                {post.createdAt ? formatDate(post.createdAt as string) : ""}
               </span>
               <span className="flex items-center gap-1">
                 <Eye size={14} /> {post.viewCount ?? 0}
@@ -127,7 +149,9 @@ export default function BoardDetailPage() {
 
             {/* 댓글 목록 */}
             {commentsQuery.isLoading ? (
-              <div className="py-10 text-center text-sm text-gray-400">댓글을 불러오는 중...</div>
+              <div className="py-10 text-center text-sm text-gray-400">
+                댓글을 불러오는 중...
+              </div>
             ) : comments.length === 0 ? (
               <CommentEmpty />
             ) : (
@@ -159,29 +183,53 @@ export default function BoardDetailPage() {
                 className="w-full resize-none text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
               />
               <div className="mt-2 flex items-center justify-between">
-                <span className="text-xs text-gray-400">{comment.length} / 1,000</span>
+                <span className="text-xs text-gray-400">
+                  {comment.length} / 1,000
+                </span>
                 <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setAnonymous((v) => !v)}
-                    aria-pressed={anonymous}
-                    className={`flex items-center gap-1.5 text-sm transition-colors ${
-                      anonymous ? "text-gray-800" : "text-gray-400 hover:text-gray-600"
-                    }`}
-                  >
-                    <span
-                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
-                        anonymous ? "border-gray-800 bg-gray-800" : "border-gray-300"
+                  {post.isAnonymous ? (
+                    <span className="text-sm text-gray-400">
+                      익명으로 작성됩니다
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setAnonymous((v) => !v)}
+                      aria-pressed={anonymous}
+                      className={`flex items-center gap-1.5 text-sm transition-colors ${
+                        anonymous
+                          ? "text-gray-800"
+                          : "text-gray-400 hover:text-gray-600"
                       }`}
                     >
-                      {anonymous && (
-                        <svg width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
-                          <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      )}
-                    </span>
-                    익명으로 작성
-                  </button>
+                      <span
+                        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
+                          anonymous
+                            ? "border-gray-800 bg-gray-800"
+                            : "border-gray-300"
+                        }`}
+                      >
+                        {anonymous && (
+                          <svg
+                            width="10"
+                            height="8"
+                            viewBox="0 0 10 8"
+                            fill="none"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M1 4L3.5 6.5L9 1"
+                              stroke="white"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </span>
+                      익명으로 작성
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={handleCommentSubmit}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -8,7 +8,7 @@ import Pagination from "@/components/shared/Pagination";
 import Tabs from "@/components/common/Tabs";
 import SearchBar from "@/components/common/SearchBar";
 import { useFreeboardList } from "@/hooks/board";
-import type { FreeBoardListItem } from "@/api";
+import { freeboardAuthorLabel, type FreeBoardListItem } from "@/api";
 import { formatDate } from "@/lib/date";
 
 const CATEGORY_TABS = ["전체", "일상", "질문", "잡담", "홍보"] as const;
@@ -22,11 +22,15 @@ export default function BoardPage() {
   const { data, isLoading } = useFreeboardList({ page: currentPage });
 
   const posts: FreeBoardListItem[] = data?.items ?? [];
-  const totalPages = Array.from({ length: data?.totalPages ?? 1 }, (_, i) => i + 1);
+  const totalPages = Array.from(
+    { length: data?.totalPages ?? 1 },
+    (_, i) => i + 1,
+  );
 
   const filtered = posts.filter((p) => {
     const matchTab = activeTab === "전체" || p.category === activeTab;
-    const matchSearch = (p.title ?? "").includes(search) || (p.authorName ?? "").includes(search);
+    const matchSearch =
+      (p.title ?? "").includes(search) || (p.authorName ?? "").includes(search);
     return matchTab && matchSearch;
   });
 
@@ -36,7 +40,9 @@ export default function BoardPage() {
         <div className="container-x-lg">
           <div className="pt-6 lg:pt-16 pb-6">
             <h1 className="text-h1 text-gray-900 mb-2">자유게시판</h1>
-            <p className="text-gray-700">익명·실명 어떤 이름으로든 자유롭게 이야기해요 (부적절한 글은 신고)</p>
+            <p className="text-gray-700">
+              익명·실명 어떤 이름으로든 자유롭게 이야기해요 (부적절한 글은 신고)
+            </p>
           </div>
 
           {/* 탭 + 검색 + 글 작성 */}
@@ -72,7 +78,9 @@ export default function BoardPage() {
             </div>
 
             {isLoading ? (
-              <div className="py-16 text-center text-sm text-gray-400">불러오는 중...</div>
+              <div className="py-16 text-center text-sm text-gray-400">
+                불러오는 중...
+              </div>
             ) : filtered.length === 0 ? (
               <div className="py-16 text-center text-sm text-gray-900">
                 {search ? "검색 결과가 없습니다." : "게시글이 없습니다."}
@@ -85,12 +93,14 @@ export default function BoardPage() {
                   className="flex items-center gap-8 px-2 py-6 border-b border-gray-100 transition-colors hover:bg-gray-50"
                 >
                   <span className="w-28 text-center shrink-0 text-sm text-gray-900 truncate">
-                    {post.isAnonymous ? "익명" : (post.authorName ?? "")}
+                    {freeboardAuthorLabel(post)}
                   </span>
                   <span className="flex-1 flex items-center gap-1.5 min-w-0 text-sm text-gray-900">
                     <span className="truncate">{post.title}</span>
                     {(post.commentCount ?? 0) > 0 && (
-                      <span className="shrink-0 text-brand text-xs">[{post.commentCount}]</span>
+                      <span className="shrink-0 text-brand text-xs">
+                        [{post.commentCount}]
+                      </span>
                     )}
                   </span>
                   <span className="w-28 text-center shrink-0 text-sm text-gray-900">

--- a/src/components/admin/NewMemberManageSection.tsx
+++ b/src/components/admin/NewMemberManageSection.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useEffect } from "react";
 import { Search } from "lucide-react";
+import { AxiosError } from "axios";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   applicantApi,
@@ -33,7 +34,9 @@ function baseDecision(item: ApplicationListItem): FinalDecision {
 export default function NewMemberManageSection() {
   const queryClient = useQueryClient();
   const canFinalize = useCan("applications.finalize");
+  const canManageRecruitment = useCan("recruitment.manage");
   const [searchQuery, setSearchQuery] = useState("");
+  const [newGeneration, setNewGeneration] = useState("");
   const [overrides, setOverrides] = useState<
     Record<string, "ACCEPT" | "REJECT">
   >({});
@@ -46,10 +49,18 @@ export default function NewMemberManageSection() {
     null | "finalize" | "close"
   >(null);
 
-  // 1) 현재 모집
-  const { data: recruitment } = useQuery({
+  // 1) 현재 모집 — 진행 중 모집이 없으면 404 → 에러가 아닌 "모집 없음(null)"으로 취급
+  const { data: recruitment, isLoading: recruitmentLoading } = useQuery({
     queryKey: ["admin", "recruitment", "current"],
-    queryFn: async () => (await recruitmentApi.getCurrent()).data.data,
+    queryFn: async () => {
+      try {
+        return (await recruitmentApi.getCurrent()).data.data;
+      } catch (err) {
+        if (err instanceof AxiosError && err.response?.status === 404)
+          return null;
+        throw err;
+      }
+    },
   });
   const recruitmentUuid = recruitment?.recruitmentUuid ?? null;
 
@@ -149,6 +160,35 @@ export default function NewMemberManageSection() {
       alert("처리 중 오류가 발생했습니다. 다시 시도해주세요.");
     },
   });
+
+  // 모집 시작 — 시작 시점 운영진 수가 투표자 수로 고정된다 (recruitment.manage 전용)
+  const startMutation = useMutation({
+    mutationFn: (generation: number) => recruitmentApi.create(generation),
+    onSuccess: () => {
+      setNewGeneration("");
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "recruitment", "current"],
+      });
+    },
+    onError: () =>
+      alert("모집 시작 중 오류가 발생했습니다. 다시 시도해주세요."),
+  });
+
+  const handleStart = () => {
+    const generation = Number(newGeneration);
+    if (!Number.isInteger(generation) || generation <= 0) {
+      alert("기수를 숫자로 입력해주세요. (예: 12)");
+      return;
+    }
+    if (
+      !window.confirm(
+        `${generation}기 모집을 시작합니다.\n\n` +
+          `시작 시점의 운영진 수가 투표자 수로 고정됩니다.\n계속하시겠습니까?`,
+      )
+    )
+      return;
+    startMutation.mutate(generation);
+  };
 
   const handleDecisionSelect = (uuid: string, value: "ACCEPT" | "REJECT") => {
     setOverrides((prev) => ({ ...prev, [uuid]: value }));
@@ -388,6 +428,44 @@ export default function NewMemberManageSection() {
             </div>
           </>
         )}
+      </div>
+    );
+  }
+
+  // ── 모집 없음(시작 전) 화면 ────────────────────────────────
+  if (!recruitmentLoading && recruitment === null) {
+    return (
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-h1 text-gray-900 mb-5">신청서 조회</h1>
+
+        <div className="rounded-2xl border border-gray-200 py-20 text-center">
+          <p className="text-gray-500">진행 중인 모집이 없습니다.</p>
+
+          {canManageRecruitment ? (
+            <div className="mt-6 flex items-center justify-center gap-2">
+              <input
+                type="number"
+                min={1}
+                value={newGeneration}
+                onChange={(e) => setNewGeneration(e.target.value)}
+                placeholder="기수 (예: 12)"
+                className="w-32 rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-center outline-none placeholder:text-gray-400 focus:border-gray-400"
+              />
+              <button
+                type="button"
+                onClick={handleStart}
+                disabled={startMutation.isPending || !newGeneration.trim()}
+                className="px-5 py-2.5 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:opacity-90 active:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+              >
+                {startMutation.isPending ? "모집 시작 중..." : "모집 시작"}
+              </button>
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-gray-400">
+              모집 시작 권한이 있는 운영진에게 문의해주세요.
+            </p>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/hooks/board/useFreeboardDetail.ts
+++ b/src/hooks/board/useFreeboardDetail.ts
@@ -1,7 +1,14 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { freeboardApi, commentApi, postApi, extractCommentList, type FreeBoardPost, type CommentItem } from "@/api";
+import {
+  freeboardApi,
+  commentApi,
+  postApi,
+  extractCommentList,
+  type FreeBoardPost,
+  type CommentItem,
+} from "@/api";
 import { formatDate } from "@/lib/date";
 
 export type MappedComment = {
@@ -15,9 +22,15 @@ export type MappedComment = {
 };
 
 function mapComment(c: CommentItem): MappedComment {
+  const name = c.userName ?? c.authorName;
   return {
     id: c.commentId,
-    author: c.userName ?? c.authorName ?? "익명",
+    // 댓글별 isAnonymous 분기 — 익명 댓글엔 작성자 필드 자체가 없음
+    author: name
+      ? c.generation != null
+        ? `${c.generation}기 ${name}`
+        : name
+      : "익명",
     userId: c.userId,
     content: c.content,
     date: c.createdAt ? formatDate(c.createdAt) : "",
@@ -38,33 +51,51 @@ export function useFreeboardDetail(postId: number) {
     enabled: !!postId,
   });
 
+  // 댓글 목록 — 자게 전용 단일 엔드포인트, 댓글별 isAnonymous로 스키마 분기
   const commentsQuery = useQuery({
     queryKey: ["freeboard-comments", postId],
     queryFn: async () => {
-      const res = await commentApi.getPostComments(postId);
+      const res = await freeboardApi.getComments(postId);
       return extractCommentList(res.data).map(mapComment);
     },
     enabled: !!postId,
   });
 
   const createComment = useMutation({
-    mutationFn: ({ content, isAnonymous }: { content: string; isAnonymous: boolean }) =>
-      commentApi.createPostComment(postId, { content, isAnonymous }),
+    // 익명 여부는 쿼리 파라미터 — 익명 글이면 서버가 값과 무관하게 익명 처리
+    mutationFn: ({
+      content,
+      isAnonymous,
+    }: {
+      content: string;
+      isAnonymous: boolean;
+    }) => freeboardApi.createComment(postId, content, isAnonymous),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const replyComment = useMutation({
-    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
-      commentApi.reply(commentId, { content }),
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) => commentApi.reply(commentId, { content }),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const deleteComment = useMutation({
     mutationFn: (commentId: number) => commentApi.delete(commentId),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const deletePost = useMutation({
@@ -76,8 +107,13 @@ export function useFreeboardDetail(postId: number) {
   });
 
   const flagComment = useMutation({
-    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
-      commentApi.flag(commentId, content),
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) => commentApi.flag(commentId, content),
   });
 
   return {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #220

## 🎀 PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정

## ✨ 추가/수정 내용
**① 무엇을**
- **모집 시작**: 진행 중 모집이 없을 때(`getCurrent` 404) 빈 상태 화면 + "모집 시작" 버튼(기수 입력). `useCan("recruitment.manage")` 게이팅, 시작 시 투표 인원 고정 안내 confirm
- `recruitmentApi.create` 추가 / 중복 `recruitmentApi.close` 제거(기존 `applicantApi.close`가 마감 flow에서 사용 중)
- **자유게시판 2026-07-02 신규 명세 반영**
  - 작성자 표기 `{authorGeneration}기 {authorName}` (익명이면 "익명") — `freeboardAuthorLabel` 헬퍼로 목록/상세 통일
  - 댓글 조회/작성을 `GET/POST /freeboard/{postId}/comment` 단일 엔드포인트로 전환 (기존 `/post/{id}/comment` 사용 제거), 목록은 댓글별 `isAnonymous` 분기
  - 댓글 익명 규칙: 익명 글=고정 안내(서버 강제 익명), 실명 글=익명/실명 토글(`?isAnonymous=` 쿼리)

**② 왜 이 방식으로**
- 7/1 API 감사 미연결 항목(모집 시작) 해소 + 7/2 BE 자게 명세 변경(단일 댓글 엔드포인트, authorGeneration) 대응
- close 중복은 finalize flow와 한 세트인 기존 함수 유지가 안전

**③ 어떻게 테스트했는지**
- `npx tsc --noEmit` + `npm run build` 통과
- ⚠️ 자게 댓글/모집 시작 실동작은 **BE 신규 명세 배포 후** dev에서 확인 필요 (프론트 단독으로는 신규 엔드포인트 검증 불가)

## 🎊 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (빌드/타입 체크 — 실동작은 BE 배포 대기)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모집 시작 기능이 추가되어, 관리자 화면에서 새 기수를 바로 개설할 수 있습니다.
  * 게시판 댓글 조회 및 작성 기능이 확장되었고, 댓글 작성 시 익명 여부를 선택할 수 있습니다.
  * 게시글과 댓글의 작성자 표기가 기수 정보까지 포함해 더 명확해졌습니다.

* **Bug Fixes**
  * 게시글이 익명인 경우 댓글도 자동으로 익명 처리되도록 동작이 개선되었습니다.
  * 모집이 없는 상태를 더 정확하게 표시하도록 화면 흐름이 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->