### PR TITLE
Feat: 동아리 일정 설정 탭 — 모집 관리 + 온보딩 링크

### DIFF
--- a/src/api/applicant.api.ts
+++ b/src/api/applicant.api.ts
@@ -116,9 +116,15 @@ export type FinalizeDecision = {
 };
 
 export const recruitmentApi = {
-  /** 현재 진행 중인 모집 */
+  /** 현재 진행 중인 모집 (없으면 404) */
   getCurrent: () =>
     api.get<ApiEnvelope<Recruitment>>("/admin/recruitments/current"),
+
+  /** 모집 시작 — 시작 시점 운영진 수를 투표자 수로 고정 */
+  create: (generation: number) =>
+    api.post<ApiEnvelope<Recruitment>>("/admin/recruitments", { generation }),
+
+  // 모집 종료는 applicantApi.close 사용 (finalize flow와 한 세트)
 
   /** 모집 요약(상태별 카운트·투표 카드) */
   getSummary: (recruitmentUuid: string) =>

--- a/src/api/freeboard.api.ts
+++ b/src/api/freeboard.api.ts
@@ -12,7 +12,10 @@ export type FreeBoardUpdateBody = Partial<FreeBoardCreateBody>;
 export type FreeBoardListItem = {
   postId: number;
   title: string;
+  /** 실명 글에만 존재 (익명 글은 작성자 필드 자체가 없음) */
   authorName?: string;
+  /** 작성자 기수 — authorName과 따로 내려옴 (2026-07-02 명세: authorGeneration) */
+  authorGeneration?: number;
   authorId?: string | number;
   isAnonymous?: boolean;
   category?: string;
@@ -21,6 +24,18 @@ export type FreeBoardListItem = {
   createdAt?: string;
   [key: string]: unknown;
 };
+
+/** 작성자 표기 — 익명이면 "익명", 아니면 "{authorGeneration}기 {authorName}" */
+export function freeboardAuthorLabel(p: {
+  isAnonymous?: boolean;
+  authorName?: string;
+  authorGeneration?: number;
+}): string {
+  if (p.isAnonymous || !p.authorName) return "익명";
+  return p.authorGeneration != null
+    ? `${p.authorGeneration}기 ${p.authorName}`
+    : p.authorName;
+}
 
 export type FreeBoardListResponse = {
   content: FreeBoardListItem[];
@@ -55,4 +70,24 @@ export const freeboardApi = {
   /** 게시글 신고 */
   flag: (postId: number, content: string) =>
     api.post<ApiEnvelope<null>>(`/post/${postId}/flag`, { content }),
+
+  /**
+   * 자게 댓글 목록 — 단일 엔드포인트, 댓글별 isAnonymous로 스키마 분기
+   * (익명 댓글엔 userId/userName/generation 없음)
+   */
+  getComments: (postId: number) =>
+    api.get<{ data?: unknown }>(`/freeboard/${postId}/comment`),
+
+  /**
+   * 자게 댓글 작성 — 익명 여부는 쿼리 파라미터.
+   * 게시글 자체가 익명이면 isAnonymous 값과 무관하게 무조건 익명 처리(서버).
+   */
+  createComment: (postId: number, content: string, isAnonymous: boolean) =>
+    api.post(
+      `/freeboard/${postId}/comment`,
+      { content },
+      {
+        params: { isAnonymous },
+      },
+    ),
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -156,6 +156,7 @@ export {
 // Free Board
 export {
   freeboardApi,
+  freeboardAuthorLabel,
   type FreeBoardCreateBody,
   type FreeBoardUpdateBody,
   type FreeBoardListItem,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -153,6 +153,9 @@ export {
   type NewsSearchInfo,
 } from "./news.api";
 
+// Settings
+export { settingsApi, type OnboardingLinks } from "./settings.api";
+
 // Free Board
 export {
   freeboardApi,

--- a/src/api/settings.api.ts
+++ b/src/api/settings.api.ts
@@ -1,0 +1,25 @@
+/**
+ * 시스템 설정 API
+ */
+import { api } from "./client";
+import { type ApiEnvelope } from "./auth.api";
+
+/** 합격/승인 안내 메일에 들어가는 온보딩 링크 */
+export type OnboardingLinks = {
+  frontendUrl: string;
+  openChatUrl: string;
+  discordUrl: string;
+};
+
+export const settingsApi = {
+  /** 온보딩 링크 조회 — 회장/부회장/ADMIN */
+  getOnboardingLinks: () =>
+    api.get<ApiEnvelope<OnboardingLinks>>("/admin/settings/onboarding-links"),
+
+  /** 온보딩 링크 수정 */
+  updateOnboardingLinks: (data: OnboardingLinks) =>
+    api.put<ApiEnvelope<OnboardingLinks>>(
+      "/admin/settings/onboarding-links",
+      data,
+    ),
+};

--- a/src/app/board/[id]/page.tsx
+++ b/src/app/board/[id]/page.tsx
@@ -9,6 +9,7 @@ import { CommentItem } from "@/components/detail/CommentSection";
 import CommentEmpty from "@/components/detail/CommentEmpty";
 import { useIsAuthor } from "@/hooks/auth";
 import { useFreeboardDetail } from "@/hooks/board";
+import { freeboardAuthorLabel } from "@/api";
 import { useUserStore } from "@/store/userStore";
 import { formatDate } from "@/lib/date";
 import type { MappedComment } from "@/hooks/board";
@@ -22,13 +23,22 @@ export default function BoardDetailPage() {
   const params = useParams();
   const postId = Number(params.id);
   const [comment, setComment] = useState("");
-  const [anonymous, setAnonymous] = useState(true);
+  // 댓글 익명 규칙: 익명 글 → 무조건 익명(서버 강제), 실명 글 → 익명/실명 선택
+  const [anonymous, setAnonymous] = useState(false);
 
   const userId = useUserStore((s) => s.userId);
   const currentUserId = userId ? Number(userId) : null;
 
-  const { postQuery, commentsQuery, createComment, replyComment, deleteComment, deletePost, flagPost, flagComment } =
-    useFreeboardDetail(postId);
+  const {
+    postQuery,
+    commentsQuery,
+    createComment,
+    replyComment,
+    deleteComment,
+    deletePost,
+    flagPost,
+    flagComment,
+  } = useFreeboardDetail(postId);
 
   const post = postQuery.data;
   const comments = commentsQuery.data ?? [];
@@ -39,7 +49,10 @@ export default function BoardDetailPage() {
   const handleCommentSubmit = async () => {
     const trimmed = comment.trim();
     if (!trimmed || createComment.isPending) return;
-    await createComment.mutateAsync({ content: trimmed, isAnonymous: anonymous });
+    await createComment.mutateAsync({
+      content: trimmed,
+      isAnonymous: post?.isAnonymous ? true : anonymous,
+    });
     setComment("");
   };
 
@@ -67,7 +80,9 @@ export default function BoardDetailPage() {
     return (
       <RequireMember>
         <main className="min-h-screen bg-white">
-          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">불러오는 중...</div>
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-400">
+            불러오는 중...
+          </div>
         </main>
       </RequireMember>
     );
@@ -77,7 +92,9 @@ export default function BoardDetailPage() {
     return (
       <RequireMember>
         <main className="min-h-screen bg-white">
-          <div className="container-x-lg pt-16 text-center text-sm text-gray-500">게시글을 찾을 수 없습니다.</div>
+          <div className="container-x-lg pt-16 text-center text-sm text-gray-500">
+            게시글을 찾을 수 없습니다.
+          </div>
         </main>
       </RequireMember>
     );
@@ -97,7 +114,11 @@ export default function BoardDetailPage() {
                 <ChevronLeft size={16} /> 목록으로
               </button>
               <KebabMenu
-                onEdit={canModify ? () => router.push(`/board/write?edit=${postId}`) : undefined}
+                onEdit={
+                  canModify
+                    ? () => router.push(`/board/write?edit=${postId}`)
+                    : undefined
+                }
                 onDelete={canModify ? handleDelete : undefined}
                 onReport={!canModify ? handleFlag : undefined}
               />
@@ -106,11 +127,12 @@ export default function BoardDetailPage() {
             {/* 제목 / 작성자 / 메타 */}
             <h1 className="mt-4 text-h1 text-gray-900">{post.title}</h1>
             <p className="mt-3 text-base text-gray-600">
-              {post.isAnonymous ? "익명" : (post.authorName ?? "")}
+              {freeboardAuthorLabel(post)}
             </p>
             <div className="mt-3 flex items-center gap-4 border-b border-gray-200 pb-6 text-sm text-gray-600">
               <span className="flex items-center gap-1">
-                <Clock size={14} /> {post.createdAt ? formatDate(post.createdAt as string) : ""}
+                <Clock size={14} />{" "}
+                {post.createdAt ? formatDate(post.createdAt as string) : ""}
               </span>
               <span className="flex items-center gap-1">
                 <Eye size={14} /> {post.viewCount ?? 0}
@@ -127,7 +149,9 @@ export default function BoardDetailPage() {
 
             {/* 댓글 목록 */}
             {commentsQuery.isLoading ? (
-              <div className="py-10 text-center text-sm text-gray-400">댓글을 불러오는 중...</div>
+              <div className="py-10 text-center text-sm text-gray-400">
+                댓글을 불러오는 중...
+              </div>
             ) : comments.length === 0 ? (
               <CommentEmpty />
             ) : (
@@ -159,29 +183,53 @@ export default function BoardDetailPage() {
                 className="w-full resize-none text-sm text-gray-700 placeholder-gray-400 focus:outline-none"
               />
               <div className="mt-2 flex items-center justify-between">
-                <span className="text-xs text-gray-400">{comment.length} / 1,000</span>
+                <span className="text-xs text-gray-400">
+                  {comment.length} / 1,000
+                </span>
                 <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => setAnonymous((v) => !v)}
-                    aria-pressed={anonymous}
-                    className={`flex items-center gap-1.5 text-sm transition-colors ${
-                      anonymous ? "text-gray-800" : "text-gray-400 hover:text-gray-600"
-                    }`}
-                  >
-                    <span
-                      className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
-                        anonymous ? "border-gray-800 bg-gray-800" : "border-gray-300"
+                  {post.isAnonymous ? (
+                    <span className="text-sm text-gray-400">
+                      익명으로 작성됩니다
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setAnonymous((v) => !v)}
+                      aria-pressed={anonymous}
+                      className={`flex items-center gap-1.5 text-sm transition-colors ${
+                        anonymous
+                          ? "text-gray-800"
+                          : "text-gray-400 hover:text-gray-600"
                       }`}
                     >
-                      {anonymous && (
-                        <svg width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
-                          <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                        </svg>
-                      )}
-                    </span>
-                    익명으로 작성
-                  </button>
+                      <span
+                        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors ${
+                          anonymous
+                            ? "border-gray-800 bg-gray-800"
+                            : "border-gray-300"
+                        }`}
+                      >
+                        {anonymous && (
+                          <svg
+                            width="10"
+                            height="8"
+                            viewBox="0 0 10 8"
+                            fill="none"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M1 4L3.5 6.5L9 1"
+                              stroke="white"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </span>
+                      익명으로 작성
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={handleCommentSubmit}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -8,7 +8,7 @@ import Pagination from "@/components/shared/Pagination";
 import Tabs from "@/components/common/Tabs";
 import SearchBar from "@/components/common/SearchBar";
 import { useFreeboardList } from "@/hooks/board";
-import type { FreeBoardListItem } from "@/api";
+import { freeboardAuthorLabel, type FreeBoardListItem } from "@/api";
 import { formatDate } from "@/lib/date";
 
 const CATEGORY_TABS = ["전체", "일상", "질문", "잡담", "홍보"] as const;
@@ -22,11 +22,15 @@ export default function BoardPage() {
   const { data, isLoading } = useFreeboardList({ page: currentPage });
 
   const posts: FreeBoardListItem[] = data?.items ?? [];
-  const totalPages = Array.from({ length: data?.totalPages ?? 1 }, (_, i) => i + 1);
+  const totalPages = Array.from(
+    { length: data?.totalPages ?? 1 },
+    (_, i) => i + 1,
+  );
 
   const filtered = posts.filter((p) => {
     const matchTab = activeTab === "전체" || p.category === activeTab;
-    const matchSearch = (p.title ?? "").includes(search) || (p.authorName ?? "").includes(search);
+    const matchSearch =
+      (p.title ?? "").includes(search) || (p.authorName ?? "").includes(search);
     return matchTab && matchSearch;
   });
 
@@ -36,7 +40,9 @@ export default function BoardPage() {
         <div className="container-x-lg">
           <div className="pt-6 lg:pt-16 pb-6">
             <h1 className="text-h1 text-gray-900 mb-2">자유게시판</h1>
-            <p className="text-gray-700">익명·실명 어떤 이름으로든 자유롭게 이야기해요 (부적절한 글은 신고)</p>
+            <p className="text-gray-700">
+              익명·실명 어떤 이름으로든 자유롭게 이야기해요 (부적절한 글은 신고)
+            </p>
           </div>
 
           {/* 탭 + 검색 + 글 작성 */}
@@ -72,7 +78,9 @@ export default function BoardPage() {
             </div>
 
             {isLoading ? (
-              <div className="py-16 text-center text-sm text-gray-400">불러오는 중...</div>
+              <div className="py-16 text-center text-sm text-gray-400">
+                불러오는 중...
+              </div>
             ) : filtered.length === 0 ? (
               <div className="py-16 text-center text-sm text-gray-900">
                 {search ? "검색 결과가 없습니다." : "게시글이 없습니다."}
@@ -85,12 +93,14 @@ export default function BoardPage() {
                   className="flex items-center gap-8 px-2 py-6 border-b border-gray-100 transition-colors hover:bg-gray-50"
                 >
                   <span className="w-28 text-center shrink-0 text-sm text-gray-900 truncate">
-                    {post.isAnonymous ? "익명" : (post.authorName ?? "")}
+                    {freeboardAuthorLabel(post)}
                   </span>
                   <span className="flex-1 flex items-center gap-1.5 min-w-0 text-sm text-gray-900">
                     <span className="truncate">{post.title}</span>
                     {(post.commentCount ?? 0) > 0 && (
-                      <span className="shrink-0 text-brand text-xs">[{post.commentCount}]</span>
+                      <span className="shrink-0 text-brand text-xs">
+                        [{post.commentCount}]
+                      </span>
                     )}
                   </span>
                   <span className="w-28 text-center shrink-0 text-sm text-gray-900">

--- a/src/components/admin/AdminPageClient.tsx
+++ b/src/components/admin/AdminPageClient.tsx
@@ -8,6 +8,7 @@ import GroupManageSection from "@/components/admin/GroupManageSection";
 import ReportManageSection from "@/components/manage/ReportManageSection";
 import NewMemberManageSection from "@/components/admin/NewMemberManageSection";
 import StaffAssignSection from "@/components/admin/StaffAssignSection";
+import ClubScheduleSettingsSection from "@/components/admin/ClubScheduleSettingsSection";
 import { useCan } from "@/hooks/auth/useCan";
 import type { Capability } from "@/lib/permissions";
 
@@ -22,6 +23,11 @@ const ADMIN_MENU_ITEMS = [
     capability: "applications.review",
   },
   { label: "운영진 지정", value: "staff", capability: "staff.assign" },
+  {
+    label: "동아리 일정 설정",
+    value: "settings",
+    capability: "system.settings",
+  },
 ] as const satisfies readonly {
   label: string;
   value: string;
@@ -42,6 +48,7 @@ export default function AdminPageClient() {
     reports: useCan("reportDocs.manage"),
     "new-members": useCan("applications.review"),
     staff: useCan("staff.assign"),
+    settings: useCan("system.settings"),
   };
   const visibleItems = ADMIN_MENU_ITEMS.filter((item) => canMap[item.value]);
 
@@ -51,7 +58,8 @@ export default function AdminPageClient() {
       tabParam === "groups" ||
       tabParam === "reports" ||
       tabParam === "new-members" ||
-      tabParam === "staff"
+      tabParam === "staff" ||
+      tabParam === "settings"
     ) {
       return tabParam as AdminMenuValue;
     }
@@ -90,6 +98,7 @@ export default function AdminPageClient() {
           {effectiveMenu === "reports" && <ReportManageSection />}
           {effectiveMenu === "new-members" && <NewMemberManageSection />}
           {effectiveMenu === "staff" && <StaffAssignSection />}
+          {effectiveMenu === "settings" && <ClubScheduleSettingsSection />}
         </div>
       </div>
     </main>

--- a/src/components/admin/ClubScheduleSettingsSection.tsx
+++ b/src/components/admin/ClubScheduleSettingsSection.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useState } from "react";
+import { AxiosError } from "axios";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { recruitmentApi, settingsApi, type OnboardingLinks } from "@/api";
+import { useCan } from "@/hooks/auth";
+import { formatDate } from "@/lib/date";
+
+const EMPTY_LINKS: OnboardingLinks = {
+  frontendUrl: "",
+  openChatUrl: "",
+  discordUrl: "",
+};
+
+const LINK_FIELDS: {
+  key: keyof OnboardingLinks;
+  label: string;
+  placeholder: string;
+}[] = [
+  {
+    key: "frontendUrl",
+    label: "홈페이지",
+    placeholder: "https://tukcbu.com",
+  },
+  {
+    key: "openChatUrl",
+    label: "카카오 오픈채팅",
+    placeholder: "https://open.kakao.com/o/...",
+  },
+  {
+    key: "discordUrl",
+    label: "디스코드",
+    placeholder: "https://discord.gg/...",
+  },
+];
+
+function isValidUrl(value: string): boolean {
+  return /^https?:\/\/.+/.test(value.trim());
+}
+
+export default function ClubScheduleSettingsSection() {
+  const queryClient = useQueryClient();
+  const canManageRecruitment = useCan("recruitment.manage");
+  const canEditSettings = useCan("system.settings");
+
+  // ── 모집 관리 ──────────────────────────────────────────────
+  const [newGeneration, setNewGeneration] = useState("");
+
+  // 진행 중 모집이 없으면 404 → 에러가 아닌 "모집 없음(null)"으로 취급
+  const { data: recruitment, isLoading: recruitmentLoading } = useQuery({
+    queryKey: ["admin", "recruitment", "current"],
+    queryFn: async () => {
+      try {
+        return (await recruitmentApi.getCurrent()).data.data;
+      } catch (err) {
+        if (err instanceof AxiosError && err.response?.status === 404)
+          return null;
+        throw err;
+      }
+    },
+    enabled: canManageRecruitment,
+  });
+
+  const startMutation = useMutation({
+    mutationFn: (generation: number) => recruitmentApi.create(generation),
+    onSuccess: () => {
+      setNewGeneration("");
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "recruitment", "current"],
+      });
+    },
+    onError: () =>
+      alert("모집 시작 중 오류가 발생했습니다. 다시 시도해주세요."),
+  });
+
+  const handleStart = () => {
+    const generation = Number(newGeneration);
+    if (!Number.isInteger(generation) || generation <= 0) {
+      alert("기수를 숫자로 입력해주세요. (예: 12)");
+      return;
+    }
+    if (
+      !window.confirm(
+        `${generation}기 모집을 시작합니다.\n\n` +
+          `지금 등록된 운영진 수가 이번 모집의 투표 인원으로 확정됩니다.\n계속하시겠습니까?`,
+      )
+    )
+      return;
+    startMutation.mutate(generation);
+  };
+
+  // ── 온보딩 링크 ────────────────────────────────────────────
+  // 서버 값 위에 사용자 수정분만 오버레이 — effect 동기화 불필요
+  const [edited, setEdited] = useState<Partial<OnboardingLinks>>({});
+  const [linkErrors, setLinkErrors] = useState<
+    Partial<Record<keyof OnboardingLinks, string>>
+  >({});
+
+  const { data: savedLinks, isLoading: linksLoading } = useQuery({
+    queryKey: ["admin", "settings", "onboarding-links"],
+    queryFn: async () => (await settingsApi.getOnboardingLinks()).data.data,
+    enabled: canEditSettings,
+  });
+
+  const links: OnboardingLinks = { ...EMPTY_LINKS, ...savedLinks, ...edited };
+
+  const dirty =
+    savedLinks != null &&
+    LINK_FIELDS.some(({ key }) => links[key].trim() !== savedLinks[key]);
+
+  const saveMutation = useMutation({
+    mutationFn: (data: OnboardingLinks) =>
+      settingsApi.updateOnboardingLinks(data),
+    onSuccess: () => {
+      setEdited({});
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "settings", "onboarding-links"],
+      });
+      alert("온보딩 링크가 저장되었습니다.");
+    },
+    onError: () => alert("저장 중 오류가 발생했습니다. 다시 시도해주세요."),
+  });
+
+  const handleSave = () => {
+    const errors: Partial<Record<keyof OnboardingLinks, string>> = {};
+    for (const { key, label } of LINK_FIELDS) {
+      if (!isValidUrl(links[key])) {
+        errors[key] =
+          `${label} 링크를 http:// 또는 https:// 로 시작하는 주소로 입력해주세요.`;
+      }
+    }
+    setLinkErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    saveMutation.mutate({
+      frontendUrl: links.frontendUrl.trim(),
+      openChatUrl: links.openChatUrl.trim(),
+      discordUrl: links.discordUrl.trim(),
+    });
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <h1 className="text-h1 text-gray-900 mb-5">동아리 일정 설정</h1>
+
+      <div className="space-y-6">
+        {/* ── 모집 관리 ── */}
+        {canManageRecruitment && (
+          <section className="rounded-2xl border border-gray-200 p-6">
+            <h2 className="text-lg font-bold text-gray-900">모집 관리</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              신규 회원 모집 회차를 시작합니다. 마감은{" "}
+              <span className="font-medium text-gray-700">
+                신청서 조회 탭의 &ldquo;모집 마감 및 합격자 결정&rdquo;
+              </span>
+              에서 진행돼요.
+            </p>
+
+            {recruitmentLoading ? (
+              <p className="mt-5 text-sm text-gray-400">불러오는 중...</p>
+            ) : recruitment ? (
+              <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg bg-gray-50 px-4 py-3.5 text-sm">
+                <span className="inline-flex items-center gap-1.5 font-semibold text-gray-900">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                  {recruitment.generation}기 모집 진행 중
+                </span>
+                <span className="text-gray-500">
+                  시작일 {formatDate(recruitment.startedAt)}
+                </span>
+                <span className="text-gray-500">
+                  투표 인원 {recruitment.voterCount}명
+                </span>
+              </div>
+            ) : (
+              <div className="mt-5">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    value={newGeneration}
+                    onChange={(e) => setNewGeneration(e.target.value)}
+                    placeholder="기수 (예: 12)"
+                    className="w-32 rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-center outline-none placeholder:text-gray-400 focus:border-gray-400"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleStart}
+                    disabled={startMutation.isPending || !newGeneration.trim()}
+                    className="px-5 py-2.5 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:opacity-90 active:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+                  >
+                    {startMutation.isPending ? "모집 시작 중..." : "모집 시작"}
+                  </button>
+                </div>
+                <p className="mt-2 text-caption text-gray-400">
+                  시작 시점의 운영진 수가 이번 모집의 투표 인원으로 확정돼요.
+                  운영진 정리가 끝난 뒤 시작해주세요.
+                </p>
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* ── 온보딩 링크 ── */}
+        {canEditSettings && (
+          <section className="rounded-2xl border border-gray-200 p-6">
+            <h2 className="text-lg font-bold text-gray-900">온보딩 링크</h2>
+            <p className="mt-1 text-sm text-gray-500">
+              합격 안내·회원 승인 메일에 포함되는 링크예요. 새 기수 받기 전에
+              최신인지 확인해주세요.
+            </p>
+
+            {linksLoading ? (
+              <p className="mt-5 text-sm text-gray-400">불러오는 중...</p>
+            ) : (
+              <div className="mt-5 space-y-4">
+                {LINK_FIELDS.map(({ key, label, placeholder }) => (
+                  <div key={key}>
+                    <label
+                      htmlFor={`onboarding-${key}`}
+                      className="block text-body-sm font-medium text-gray-900"
+                    >
+                      {label}
+                    </label>
+                    <input
+                      id={`onboarding-${key}`}
+                      type="url"
+                      value={links[key]}
+                      onChange={(e) =>
+                        setEdited((prev) => ({
+                          ...prev,
+                          [key]: e.target.value,
+                        }))
+                      }
+                      placeholder={placeholder}
+                      className={`mt-1.5 w-full max-w-xl rounded-lg border px-3 py-2.5 text-sm outline-none placeholder:text-gray-400 focus:border-gray-400 ${
+                        linkErrors[key] ? "border-notice" : "border-gray-200"
+                      }`}
+                    />
+                    {linkErrors[key] && (
+                      <p className="mt-1 text-caption text-notice">
+                        {linkErrors[key]}
+                      </p>
+                    )}
+                  </div>
+                ))}
+
+                <div className="flex items-center gap-3 pt-1">
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={!dirty || saveMutation.isPending}
+                    className="px-5 py-2.5 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:opacity-90 active:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+                  >
+                    {saveMutation.isPending ? "저장 중..." : "저장"}
+                  </button>
+                  {!dirty && savedLinks != null && (
+                    <span className="text-caption text-gray-400">
+                      변경 사항 없음
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/NewMemberManageSection.tsx
+++ b/src/components/admin/NewMemberManageSection.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useEffect } from "react";
 import { Search } from "lucide-react";
+import { AxiosError } from "axios";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   applicantApi,
@@ -33,7 +34,9 @@ function baseDecision(item: ApplicationListItem): FinalDecision {
 export default function NewMemberManageSection() {
   const queryClient = useQueryClient();
   const canFinalize = useCan("applications.finalize");
+  const canManageRecruitment = useCan("recruitment.manage");
   const [searchQuery, setSearchQuery] = useState("");
+  const [newGeneration, setNewGeneration] = useState("");
   const [overrides, setOverrides] = useState<
     Record<string, "ACCEPT" | "REJECT">
   >({});
@@ -46,10 +49,18 @@ export default function NewMemberManageSection() {
     null | "finalize" | "close"
   >(null);
 
-  // 1) 현재 모집
-  const { data: recruitment } = useQuery({
+  // 1) 현재 모집 — 진행 중 모집이 없으면 404 → 에러가 아닌 "모집 없음(null)"으로 취급
+  const { data: recruitment, isLoading: recruitmentLoading } = useQuery({
     queryKey: ["admin", "recruitment", "current"],
-    queryFn: async () => (await recruitmentApi.getCurrent()).data.data,
+    queryFn: async () => {
+      try {
+        return (await recruitmentApi.getCurrent()).data.data;
+      } catch (err) {
+        if (err instanceof AxiosError && err.response?.status === 404)
+          return null;
+        throw err;
+      }
+    },
   });
   const recruitmentUuid = recruitment?.recruitmentUuid ?? null;
 
@@ -149,6 +160,35 @@ export default function NewMemberManageSection() {
       alert("처리 중 오류가 발생했습니다. 다시 시도해주세요.");
     },
   });
+
+  // 모집 시작 — 시작 시점 운영진 수가 투표자 수로 고정된다 (recruitment.manage 전용)
+  const startMutation = useMutation({
+    mutationFn: (generation: number) => recruitmentApi.create(generation),
+    onSuccess: () => {
+      setNewGeneration("");
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "recruitment", "current"],
+      });
+    },
+    onError: () =>
+      alert("모집 시작 중 오류가 발생했습니다. 다시 시도해주세요."),
+  });
+
+  const handleStart = () => {
+    const generation = Number(newGeneration);
+    if (!Number.isInteger(generation) || generation <= 0) {
+      alert("기수를 숫자로 입력해주세요. (예: 12)");
+      return;
+    }
+    if (
+      !window.confirm(
+        `${generation}기 모집을 시작합니다.\n\n` +
+          `시작 시점의 운영진 수가 투표자 수로 고정됩니다.\n계속하시겠습니까?`,
+      )
+    )
+      return;
+    startMutation.mutate(generation);
+  };
 
   const handleDecisionSelect = (uuid: string, value: "ACCEPT" | "REJECT") => {
     setOverrides((prev) => ({ ...prev, [uuid]: value }));
@@ -388,6 +428,44 @@ export default function NewMemberManageSection() {
             </div>
           </>
         )}
+      </div>
+    );
+  }
+
+  // ── 모집 없음(시작 전) 화면 ────────────────────────────────
+  if (!recruitmentLoading && recruitment === null) {
+    return (
+      <div className="max-w-6xl mx-auto">
+        <h1 className="text-h1 text-gray-900 mb-5">신청서 조회</h1>
+
+        <div className="rounded-2xl border border-gray-200 py-20 text-center">
+          <p className="text-gray-500">진행 중인 모집이 없습니다.</p>
+
+          {canManageRecruitment ? (
+            <div className="mt-6 flex items-center justify-center gap-2">
+              <input
+                type="number"
+                min={1}
+                value={newGeneration}
+                onChange={(e) => setNewGeneration(e.target.value)}
+                placeholder="기수 (예: 12)"
+                className="w-32 rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-center outline-none placeholder:text-gray-400 focus:border-gray-400"
+              />
+              <button
+                type="button"
+                onClick={handleStart}
+                disabled={startMutation.isPending || !newGeneration.trim()}
+                className="px-5 py-2.5 rounded-lg bg-gray-900 text-white text-sm font-semibold hover:opacity-90 active:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+              >
+                {startMutation.isPending ? "모집 시작 중..." : "모집 시작"}
+              </button>
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-gray-400">
+              모집 시작 권한이 있는 운영진에게 문의해주세요.
+            </p>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/hooks/board/useFreeboardDetail.ts
+++ b/src/hooks/board/useFreeboardDetail.ts
@@ -1,7 +1,14 @@
 "use client";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { freeboardApi, commentApi, postApi, extractCommentList, type FreeBoardPost, type CommentItem } from "@/api";
+import {
+  freeboardApi,
+  commentApi,
+  postApi,
+  extractCommentList,
+  type FreeBoardPost,
+  type CommentItem,
+} from "@/api";
 import { formatDate } from "@/lib/date";
 
 export type MappedComment = {
@@ -15,9 +22,15 @@ export type MappedComment = {
 };
 
 function mapComment(c: CommentItem): MappedComment {
+  const name = c.userName ?? c.authorName;
   return {
     id: c.commentId,
-    author: c.userName ?? c.authorName ?? "익명",
+    // 댓글별 isAnonymous 분기 — 익명 댓글엔 작성자 필드 자체가 없음
+    author: name
+      ? c.generation != null
+        ? `${c.generation}기 ${name}`
+        : name
+      : "익명",
     userId: c.userId,
     content: c.content,
     date: c.createdAt ? formatDate(c.createdAt) : "",
@@ -38,33 +51,51 @@ export function useFreeboardDetail(postId: number) {
     enabled: !!postId,
   });
 
+  // 댓글 목록 — 자게 전용 단일 엔드포인트, 댓글별 isAnonymous로 스키마 분기
   const commentsQuery = useQuery({
     queryKey: ["freeboard-comments", postId],
     queryFn: async () => {
-      const res = await commentApi.getPostComments(postId);
+      const res = await freeboardApi.getComments(postId);
       return extractCommentList(res.data).map(mapComment);
     },
     enabled: !!postId,
   });
 
   const createComment = useMutation({
-    mutationFn: ({ content, isAnonymous }: { content: string; isAnonymous: boolean }) =>
-      commentApi.createPostComment(postId, { content, isAnonymous }),
+    // 익명 여부는 쿼리 파라미터 — 익명 글이면 서버가 값과 무관하게 익명 처리
+    mutationFn: ({
+      content,
+      isAnonymous,
+    }: {
+      content: string;
+      isAnonymous: boolean;
+    }) => freeboardApi.createComment(postId, content, isAnonymous),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const replyComment = useMutation({
-    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
-      commentApi.reply(commentId, { content }),
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) => commentApi.reply(commentId, { content }),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const deleteComment = useMutation({
     mutationFn: (commentId: number) => commentApi.delete(commentId),
     onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["freeboard-comments", postId] }),
+      queryClient.invalidateQueries({
+        queryKey: ["freeboard-comments", postId],
+      }),
   });
 
   const deletePost = useMutation({
@@ -76,8 +107,13 @@ export function useFreeboardDetail(postId: number) {
   });
 
   const flagComment = useMutation({
-    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
-      commentApi.flag(commentId, content),
+    mutationFn: ({
+      commentId,
+      content,
+    }: {
+      commentId: number;
+      content: string;
+    }) => commentApi.flag(commentId, content),
   });
 
   return {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #221

> ⚠️ **스택 PR**: #222(feat/220) 위에 쌓여 있어요 — 모집 관리 카드가 `recruitmentApi.create`를 사용해서요. **#222 머지 후 base를 develop으로 변경(자동 retarget)하고 rebase 후 머지해주세요.**

## 🎀 PR 유형
- [x] 새로운 기능 추가

## ✨ 추가/수정 내용
**① 무엇을**
- 관리자 사이드바에 **"동아리 일정 설정"** 메뉴 신설 (`system.settings` capability — 회장/부회장/ADMIN에게만 노출)
- **모집 관리 카드**: 진행 중 모집 상태(기수·시작일·투표 인원) 조회, 없으면 모집 시작(기수 입력) — `recruitment.manage` 게이팅
- **온보딩 링크 카드**: 합격/승인 안내 메일용 링크 3종(홈페이지·오픈채팅·디스코드) 조회/수정 — `GET/PUT /admin/settings/onboarding-links`, URL 형식 검증 + 변경분(dirty) 있을 때만 저장 활성화

**② 왜 이 방식으로**
- 온보딩 링크는 합격 메일(신청서)·승인 메일(회원) 양쪽에 쓰이는 전역 설정이라 특정 도메인 탭이 아닌 별도 탭으로 분리
- 링크 폼은 서버값+수정분 오버레이 패턴(effect 동기화 없음 — react-hooks/set-state-in-effect 준수)

**③ 어떻게 테스트했는지**
- `npx tsc --noEmit` + `npm run build` 통과
- 실데이터 저장/조회는 dev 배포 후 회장 계정으로 확인 필요

## 🎊 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (빌드/타입 체크 — 실동작은 dev 확인 예정)