### PR TITLE
Feat: 내 투표 카드 applications.vote 게이팅 (ADMIN 집계 열람만)

### DIFF
--- a/src/components/admin/NewMemberManageSection.tsx
+++ b/src/components/admin/NewMemberManageSection.tsx
@@ -34,6 +34,8 @@ function baseDecision(item: ApplicationListItem): FinalDecision {
 export default function NewMemberManageSection() {
   const queryClient = useQueryClient();
   const canFinalize = useCan("applications.finalize");
+  // 투표는 운영진급만 — ADMIN(개발자 관리자)은 서버 허용 역할에 없어 집계만 열람
+  const canVote = useCan("applications.vote");
   const canManageRecruitment = useCan("recruitment.manage");
   const [searchQuery, setSearchQuery] = useState("");
   const [newGeneration, setNewGeneration] = useState("");
@@ -377,53 +379,62 @@ export default function NewMemberManageSection() {
                   )}
                 </div>
 
-                <div className="rounded-2xl border border-gray-200 p-5">
-                  <h2 className="text-base font-bold text-gray-900">내 투표</h2>
-                  <div className="mt-3 inline-flex rounded-full bg-gray-100 p-1">
+                {!canVote ? (
+                  <p className="rounded-2xl border border-gray-200 p-5 text-sm text-gray-400">
+                    투표는 운영진만 가능해요. 관리자 계정은 투표 현황 열람만
+                    지원돼요.
+                  </p>
+                ) : (
+                  <div className="rounded-2xl border border-gray-200 p-5">
+                    <h2 className="text-base font-bold text-gray-900">
+                      내 투표
+                    </h2>
+                    <div className="mt-3 inline-flex rounded-full bg-gray-100 p-1">
+                      <button
+                        type="button"
+                        onClick={() => setVoteChoice("PASS")}
+                        className={`rounded-full px-6 py-2 text-sm font-semibold transition-colors ${
+                          voteChoice === "PASS"
+                            ? "bg-success text-white"
+                            : "text-gray-500"
+                        }`}
+                      >
+                        합격
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setVoteChoice("FAIL")}
+                        className={`rounded-full px-6 py-2 text-sm font-semibold transition-colors ${
+                          voteChoice === "FAIL"
+                            ? "bg-danger text-white"
+                            : "text-gray-500"
+                        }`}
+                      >
+                        불합격
+                      </button>
+                    </div>
+                    <textarea
+                      value={voteReason}
+                      onChange={(e) => setVoteReason(e.target.value)}
+                      rows={4}
+                      aria-label="투표 사유"
+                      placeholder="사유를 입력하세요 (불합격 시 필수)"
+                      className="mt-3 w-full resize-none rounded-xl border border-gray-200 p-3 text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
+                    />
                     <button
                       type="button"
-                      onClick={() => setVoteChoice("PASS")}
-                      className={`rounded-full px-6 py-2 text-sm font-semibold transition-colors ${
-                        voteChoice === "PASS"
-                          ? "bg-success text-white"
-                          : "text-gray-500"
-                      }`}
+                      disabled={
+                        !voteChoice ||
+                        (voteChoice === "FAIL" && !voteReason.trim()) ||
+                        voteMutation.isPending
+                      }
+                      onClick={handleVoteSave}
+                      className="mt-3 w-full rounded-full bg-gray-900 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-40"
                     >
-                      합격
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setVoteChoice("FAIL")}
-                      className={`rounded-full px-6 py-2 text-sm font-semibold transition-colors ${
-                        voteChoice === "FAIL"
-                          ? "bg-danger text-white"
-                          : "text-gray-500"
-                      }`}
-                    >
-                      불합격
+                      {voteMutation.isPending ? "저장 중..." : "투표 저장"}
                     </button>
                   </div>
-                  <textarea
-                    value={voteReason}
-                    onChange={(e) => setVoteReason(e.target.value)}
-                    rows={4}
-                    aria-label="투표 사유"
-                    placeholder="사유를 입력하세요 (불합격 시 필수)"
-                    className="mt-3 w-full resize-none rounded-xl border border-gray-200 p-3 text-sm text-gray-900 placeholder-gray-400 focus:outline-none"
-                  />
-                  <button
-                    type="button"
-                    disabled={
-                      !voteChoice ||
-                      (voteChoice === "FAIL" && !voteReason.trim()) ||
-                      voteMutation.isPending
-                    }
-                    onClick={handleVoteSave}
-                    className="mt-3 w-full rounded-full bg-gray-900 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-40"
-                  >
-                    {voteMutation.isPending ? "저장 중..." : "투표 저장"}
-                  </button>
-                </div>
+                )}
               </div>
             </div>
           </>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #109

## 🎀 PR 유형
- [x] 버그 수정

## ✨ 추가/수정 내용
**① 무엇을** — 신청서 상세의 "내 투표" 카드를 `useCan("applications.vote")`로 게이팅. 권한 없는 계정(ADMIN)에는 입력 카드 대신 안내 문구 노출, 투표 현황(집계) 카드는 그대로 열람.

**② 왜** — 서버 `PUT /admin/applications/{uuid}/vote` 허용 역할에 개발자 관리자가 없어서, 지금은 ADMIN이 투표 저장을 누르면 403이 나는 상태. 이슈 완료 기준 "admin은 집계만 관여"에 맞춤.

**③ 테스트** — tsc/빌드 통과. dev에서 ADMIN·운영진 계정 각각 확인 필요.

## 📌 참고
- #109의 나머지 항목(투표 UI·불합 사유 필수·투표 현황·내 투표 수정)은 #206에서 이미 구현됨
- **"내 투표 취소"는 BE에 DELETE 엔드포인트가 없어 미구현** — 필요하면 BE 요청 후 별도 이슈

## 🎊 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (빌드/타입 체크)