### PR TITLE
Chore: 스터디/프로젝트 API 데드코드 제거 (스웨거 전수 대조)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -35,7 +35,6 @@ export {
 export {
   projectApi,
   type ProjectListParams,
-  type ProjectFilterParams,
   type ProjectListItem,
   type ProjectListResponse,
   type ProjectDetailData,

--- a/src/api/project.api.ts
+++ b/src/api/project.api.ts
@@ -13,8 +13,6 @@ export type ProjectListParams = {
   recruiting?: boolean;
 };
 
-export type ProjectFilterParams = { category?: string; page?: number; size?: number };
-
 /** 프로젝트 목록 아이템 (API 응답 content 요소) */
 export type ProjectListItem = {
   postId: number;
@@ -78,17 +76,19 @@ export type ProjectDetailData = {
   authorGeneration?: number;
   authorName?: string;
   viewCount?: number;
-  /** 작성자(팀장) 여부 - 신청 인원 확인 버튼 노출 */
+  /**
+   * 작성자(팀장) 여부 - 신청 인원 확인 버튼 노출.
+   * ⚠️ 스웨거(ProjectInfoDetailDTO)의 실제 필드는 isLeader — 스터디(leader)와 이름이 다름.
+   */
+  isLeader?: boolean;
+  /** 스터디 상세와의 호환용 별칭 — 서버 응답엔 없음, isLeader를 사용할 것 */
   leader?: boolean;
   /** 신청 여부 - 신청하기/취소하기/가입완료 분기 */
   hasApplied?: boolean;
-  /** @deprecated leader 사용 */
-  isLeader?: boolean;
 };
 export const projectApi = {
   /** 프로젝트 게시글 전체 목록 페이징 조회 */
-  getList: (params?: ProjectListParams) =>
-    api.get("/post/project", { params }),
+  getList: (params?: ProjectListParams) => api.get("/post/project", { params }),
 
   /** 프로젝트 게시글 생성 */
   create: (data: CreateProjectRequest) => api.post("/post/project", data),
@@ -103,14 +103,10 @@ export const projectApi = {
   /** 프로젝트 게시글 삭제 */
   delete: (postId: number) => api.delete(`/post/project/${postId}`),
 
-  /** 프로젝트 모집 마감 */
-  close: (postId: number) => api.post(`/post/project/${postId}/close`),
+  // 모집 마감(close) API 없음 — 스웨거엔 스터디 close만 존재. 프로젝트 마감은 update(recruiting: false) 사용 (구버전 경로 제거, #225)
+  // 분야별 필터(/post/project/filter, params: fields·recruiting)는 미사용이라 미구현 — 필요 시 스웨거 기준으로 추가
 
-  /** 내가 작성한 프로젝트 게시글 목록 조회 */
-  getMyList: (params?: ProjectListParams) =>
+  /** 내가 작성한 프로젝트 게시글 목록 조회 — /me는 recruiting 파라미터 미지원 */
+  getMyList: (params?: Omit<ProjectListParams, "recruiting">) =>
     api.get("/post/project/me", { params }),
-
-  /** 프로젝트 모집분야 카테고리별 목록 페이징 조회 */
-  getFilteredList: (params?: ProjectFilterParams) =>
-    api.get("/post/project/filter", { params }),
 };

--- a/src/api/study.api.ts
+++ b/src/api/study.api.ts
@@ -5,7 +5,11 @@
 import { api } from "./client";
 
 // page: 0부터 시작, size: 페이지 당 개수, category: 백엔드 enum 번호
-export type StudyListParams = { page?: number; size?: number; category?: number };
+export type StudyListParams = {
+  page?: number;
+  size?: number;
+  category?: number;
+};
 
 /** GET /post/study/me — Swagger상 page, size, category 필수 (스터디 category=1) */
 export type StudyMyListParams = {
@@ -24,7 +28,9 @@ export type CreateStudyRequest = {
   category: number;
 };
 
-export type UpdateStudyRequest = Partial<Omit<CreateStudyRequest, "category" | "recruiting">> & {
+export type UpdateStudyRequest = Partial<
+  Omit<CreateStudyRequest, "category" | "recruiting">
+> & {
   // 모집 상태 변경은 close API를 사용하므로 여기선 제외
 };
 
@@ -57,14 +63,14 @@ export type StudyDetailResponse = {
 
 export const studyApi = {
   /** 스터디 게시글 전체 목록 페이징 조회 (카테고리별, 최신순) */
-  getList: (params?: StudyListParams) =>
-    api.get("/post/study", { params }),
+  getList: (params?: StudyListParams) => api.get("/post/study", { params }),
 
   /** 스터디 게시글 생성 */
   create: (data: CreateStudyRequest) => api.post("/post/study", data),
 
   /** 스터디 게시글 상세 조회 */
-  getById: (postId: number) => api.get<StudyDetailResponse>("/post/study/" + postId),
+  getById: (postId: number) =>
+    api.get<StudyDetailResponse>("/post/study/" + postId),
 
   /** 스터디 게시글 수정 */
   update: (postId: number, data: UpdateStudyRequest) =>
@@ -76,20 +82,7 @@ export const studyApi = {
   /** 스터디 모집 마감 */
   close: (postId: number) => api.post(`/post/study/${postId}/close`),
 
-  /** 스터디 신청 목록 조회 */
-  getApplyList: (postId: number) =>
-    api.get(`/post/study/${postId}/apply`),
-
-  /** 스터디 참가 신청 */
-  apply: (postId: number) => api.post(`/post/study/${postId}/apply`),
-
-  /** 스터디 신청 취소 */
-  cancelApply: (postId: number) =>
-    api.delete(`/post/study/${postId}/apply`),
-
-  /** 스터디 신청 수락/거절 */
-  updateApplyStatus: (postId: number, applyId: number, data: unknown) =>
-    api.patch(`/post/study/${postId}/apply/${applyId}`, data),
+  // 신청(apply) 관련 API 없음 — 스터디 참가 신청/수락은 groups API 경유 (구버전 /apply 경로는 서버에 존재하지 않아 제거, #225)
 
   /** 내가 작성한 스터디 게시글 목록 조회 (authorName·authorGeneration 등 content 스키마) */
   getMyList: (params: StudyMyListParams) =>


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #225

## 🎀 PR 유형
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더 삭제

## ✨ 추가/수정 내용
**① 무엇을** — 라이브 스웨거(dev, 오늘 기준) 전수 대조 후 서버에 존재하지 않는 경로 제거:
| 제거 | 사유 | 사용처 |
|---|---|---|
| `studyApi` apply 4종 (`/post/study/{id}/apply*`) | 스웨거에 경로 없음 — 신청은 groups 경유 | 0곳 |
| `projectApi.close` (`/post/project/{id}/close`) | 스웨거엔 **study close만** 존재 | 0곳 |
| `projectApi.getFilteredList` + `ProjectFilterParams` | 미호출 + 파라미터 불일치(FE `category` vs 서버 `fields`·`recruiting`) | 0곳 |

부수 정정:
- `ProjectDetailData` 주석 — 서버 실제 필드는 `isLeader`(스터디는 `leader`, 서로 다름). 기존 주석이 반대로 안내하고 있었음. 소비처(`project/[id]/page.tsx:122`)는 `leader ?? isLeader` 폴백이라 동작 변화 없음
- `projectApi.getMyList` 파라미터에서 `recruiting` 제외 (`/me`는 page·size·category만 지원)

**② 왜** — 스웨거에 없는 경로가 남아 있으면 후속 작업자가 진짜 API로 오인 (실제로 오늘 "스터디/프로젝트 주소가 다르다" 혼선 발생). 나머지 메서드 전부(목록/생성/상세/수정/삭제/me/filterByTag/close)는 verb·경로·쿼리 파라미터·요청 바디 필드 단위로 스웨거와 일치 확인함 — `CreateStudyRequest`↔`PostStudyCreateRequestDTO` 7/7, `UpdateStudyRequest`↔`PostStudyUpdateRequestDTO` 5/5, `CreateProjectRequest`↔`PostProjectCreateRequestDTO` 7/7, `UpdateProjectRequest`↔`PostProjectUpdateRequestDTO` 6/6

**③ 테스트** — 제거 대상 전부 사용처 0곳 grep 확인, `tsc` + `npm run build` 통과 (삭제라 런타임 영향 없음)

## 🎊 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (사용처 grep + 빌드/타입 체크)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 변경**
  * 프로젝트 목록/상세 관련 요청 형식이 정리되어, 일부 목록 조회 옵션이 더 이상 사용되지 않습니다.
  * 내 프로젝트 목록 조회 시 받을 수 있는 조건이 일부 제한되었습니다.
  * 스터디 신청 관련 일부 기능이 API에서 제외되었습니다.

* **버그 수정**
  * 프로젝트 상세에서 팀장 여부 표시 기준이 더 명확하게 정리되었습니다.
  * 스터디 목록/상세 요청 정의가 정돈되어 사용성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->