### PR TITLE
[Fix] 모임 참석투표 요청 바디 수정 + 지원서 인증 후속 처리

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -12,7 +12,10 @@ function isPublicAuthPath(url: string): boolean {
     url.includes("/mail/") ||
     url.endsWith("/login/password/reset") ||
     url.endsWith("/login/signup") ||
-    url.endsWith("/validate")
+    url.endsWith("/validate") ||
+    // 지원서(비로그인 지원자) — 서버가 이메일 인증 실패를 401로 반환한다.
+    // /admin/applications(운영진용)는 매칭되면 안 되므로 startsWith로 제한.
+    url.startsWith("/applications")
   );
 }
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,8 +14,8 @@ function isPublicAuthPath(url: string): boolean {
     url.endsWith("/login/signup") ||
     url.endsWith("/validate") ||
     // 지원서(비로그인 지원자) — 서버가 이메일 인증 실패를 401로 반환한다.
-    // /admin/applications(운영진용)는 매칭되면 안 되므로 startsWith로 제한.
-    url.startsWith("/applications")
+    // /admin/applications(운영진용)는 매칭되면 안 되므로 세그먼트 단위로 제한.
+    /^\/applications([/?]|$)/.test(url)
   );
 }
 

--- a/src/api/gathering.api.ts
+++ b/src/api/gathering.api.ts
@@ -10,8 +10,8 @@ export type GatheringType = "DINING" | "MT" | "FAIR" | "EVENT" | "OTHER";
 /** 내 참석 상태 */
 export type MyAttendanceStatus =
   "ATTENDING" | "NOT_ATTENDING" | "UNDECIDED" | "NOT_RESPONDED";
-/** 투표 값 (서버는 참석/불참 2지선다만 받음) */
-export type VoteDecision = "PASS" | "FAIL";
+/** 투표 값 (서버는 참석/불참 2지선다만 받음 — BE GatheringDTO.VoteRequest의 AttendanceStatus) */
+export type AttendanceVote = "ATTENDING" | "NOT_ATTENDING";
 
 /** 종류 enum ↔ 한글 라벨 */
 export const GATHERING_TYPE_LABEL: Record<GatheringType, string> = {
@@ -123,9 +123,9 @@ export const gatheringApi = {
   /** 모임 삭제 */
   remove: (id: number) => api.delete<ApiEnvelope<null>>(`/gatherings/${id}`),
 
-  /** 참석 투표 (PASS=참석 / FAIL=불참) */
-  vote: (id: number, decision: VoteDecision, reason = "") =>
-    api.post<ApiEnvelope<null>>(`/gatherings/${id}/vote`, { decision, reason }),
+  /** 참석 투표 (ATTENDING=참석 / NOT_ATTENDING=불참) */
+  vote: (id: number, status: AttendanceVote) =>
+    api.post<ApiEnvelope<null>>(`/gatherings/${id}/vote`, { status }),
 
   /** 투표 마감 */
   close: (id: number) =>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -118,7 +118,8 @@ export {
   GATHERING_TYPE_LABEL,
   type GatheringType,
   type MyAttendanceStatus,
-  // VoteDecision("PASS"|"FAIL")은 applicant.api 재export와 동일 → 중복 제거(모임도 그걸 사용)
+  // VoteDecision("PASS"|"FAIL")은 지원자 합불 전용(applicant.api) — 모임 투표는 AttendanceVote 사용
+  type AttendanceVote,
   type AttendanceSummary,
   type Gathering,
   type GatheringMember,

--- a/src/app/apply/form/page.tsx
+++ b/src/app/apply/form/page.tsx
@@ -172,7 +172,7 @@ export default function ApplyFormPage() {
     return {
       ...INITIAL_FORM,
       email: draft.email.replace(/@tukorea\.ac\.kr$/, ""),
-      isEmailVerified: true,
+      // 서버가 제출 시 emailAuthCode를 Redis와 대조하므로, 복원해도 인증은 다시 받아야 함
       name: draft.name,
       nickname: draft.nickname,
       studentId: String(draft.studentNumber),

--- a/src/app/meeting/[id]/page.tsx
+++ b/src/app/meeting/[id]/page.tsx
@@ -21,7 +21,7 @@ import {
   gatheringApi,
   GATHERING_TYPE_LABEL,
   type GatheringMember,
-  type VoteDecision,
+  type AttendanceVote,
 } from "@/api";
 
 function fmt(iso?: string, pattern = "yyyy.MM.dd (EEE) HH:mm") {
@@ -35,12 +35,12 @@ function fmt(iso?: string, pattern = "yyyy.MM.dd (EEE) HH:mm") {
 
 // 참석 투표 (참석 / 불참)
 const VOTE_OPTIONS: {
-  key: VoteDecision;
+  key: AttendanceVote;
   label: string;
   emotion: MascotEmotion;
 }[] = [
-  { key: "PASS", label: "참석할게요", emotion: "default" },
-  { key: "FAIL", label: "참석이 어려워요", emotion: "sad" },
+  { key: "ATTENDING", label: "참석할게요", emotion: "default" },
+  { key: "NOT_ATTENDING", label: "참석이 어려워요", emotion: "sad" },
 ];
 
 function MemberList({ members }: { members: GatheringMember[] }) {
@@ -75,7 +75,7 @@ export default function MeetingDetailPage() {
   const closeMutation = useCloseGathering(id);
 
   // 내 기존 투표를 기본 선택으로 파생, 사용자가 바꾸면 override 우선
-  const [choiceOverride, setChoiceOverride] = useState<VoteDecision | null>(
+  const [choiceOverride, setChoiceOverride] = useState<AttendanceVote | null>(
     null,
   );
 
@@ -104,12 +104,10 @@ export default function MeetingDetailPage() {
     );
   }
 
-  const defaultChoice: VoteDecision | null =
-    meeting.myStatus === "ATTENDING"
-      ? "PASS"
-      : meeting.myStatus === "NOT_ATTENDING"
-        ? "FAIL"
-        : null;
+  const defaultChoice: AttendanceVote | null =
+    meeting.myStatus === "ATTENDING" || meeting.myStatus === "NOT_ATTENDING"
+      ? meeting.myStatus
+      : null;
   const choice = choiceOverride ?? defaultChoice;
 
   const handleDelete = () => {

--- a/src/hooks/meeting/useGatherings.ts
+++ b/src/hooks/meeting/useGatherings.ts
@@ -5,7 +5,7 @@ import {
   gatheringApi,
   type Gathering,
   type AttendanceList,
-  type VoteDecision,
+  type AttendanceVote,
   type CreateGatheringBody,
   type UpdateGatheringBody,
 } from "@/api";
@@ -82,7 +82,7 @@ export function useDeleteGathering() {
 export function useVoteGathering(id: number) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (decision: VoteDecision) => gatheringApi.vote(id, decision),
+    mutationFn: (status: AttendanceVote) => gatheringApi.vote(id, status),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: detailKey(id) });
       qc.invalidateQueries({ queryKey: attendanceKey(id) });


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #234

## 🎀 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✨ 추가/수정 내용
**무엇을**
- 모임 참석투표 요청 바디를 `{decision: PASS|FAIL, reason}` → `{status: ATTENDING|NOT_ATTENDING}`으로 수정 (모임 쪽 `VoteDecision` 중복 정의 제거, `AttendanceVote` 타입 분리)
- `client.ts` `isPublicAuthPath`에 `/applications` 추가 (`/admin/applications`는 매칭 안 되게 startsWith)
- 지원서 복원(pre-fill) 시 `isEmailVerified: true`로 되살리지 않고 이메일 재인증을 받도록 수정

**왜 이 방식으로**
- BE `GatheringDTO.VoteRequest`가 실제로 받는 바디가 `{status}`입니다. 스웨거는 지원자 쪽 `VoteRequest`와 DTO 레코드명이 충돌해 잘못 표기된 상태라(7/5 동안님 공유) BE 코드를 기준으로 맞췄습니다.
- 비로그인 지원자가 401을 받으면 인터셉터가 refresh를 시도하다 실패해 /login으로 이동하며 작성 내용이 소실됩니다. 서버가 제출 시 `emailAuthCode`를 Redis와 대조하므로, 복원된 폼은 인증을 다시 받아야만 유효한 코드로 제출할 수 있습니다.

**어떻게 테스트했는지**
- `npm run build` 통과, `npm run lint` 0 errors (warning 9건은 기존 파일들의 기존 경고)
- dev 화면에서 모임 참석/불참 투표 저장, 지원서 복원 → 재인증 요구 확인 예정

## 🎊 PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 모임 참석 투표가 ‘참석’ 또는 ‘불참’ 상태로 제공됩니다.
  - 모임 상세 화면에서 현재 참석 투표 상태를 확인하고 선택할 수 있습니다.

- **버그 수정**
  - 신청서 임시 저장 내용을 복원해도 이메일 인증 상태가 유지되지 않으며, 제출 전 인증을 다시 진행해야 합니다.
  - 인증이 필요한 주요 경로의 로그인 및 접근 처리가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->